### PR TITLE
Restore dynamic year in footer

### DIFF
--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -42,6 +42,7 @@ function setCopyrightYear() {
     const copyrightElement = document.getElementById('copyright-message');
     if (copyrightElement) {
         const currentYear = new Date().getFullYear();
-        copyrightElement.textContent = `Copyright © ${new Date().getFullYear() === 2025 ? '2025' : `2025-${currentYear}`}, D4rK`;
+        const yearText = currentYear === 2025 ? '2025' : `2025-${currentYear}`;
+        copyrightElement.textContent = `Copyright © ${yearText}, Mihai-Cristian Condrea`;
     }
 }

--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
             </md-elevated-card>
 
             <div class="social-icons">
-                <a href="https://github.com/D4rK7355608" target="_blank" rel="noopener noreferrer"
+                <a href="https://github.com/MihaiCristianCondrea" target="_blank" rel="noopener noreferrer"
                     aria-label="GitHub Profile" title="GitHub"> <md-icon-button> <md-icon><i
                                 class="fab fa-github"></i></md-icon> </md-icon-button> </a>
                 <a href="https://www.instagram.com/d4rk7355608/" target="_blank" rel="noopener noreferrer"
@@ -216,9 +216,9 @@
                 <a href="https://www.linkedin.com/in/mihai-cristian-condrea/" target="_blank" rel="noopener noreferrer"
                     aria-label="LinkedIn Profile" title="LinkedIn"> <md-icon-button> <md-icon><i
                                 class="fab fa-linkedin-in"></i></md-icon> </md-icon-button> </a>
-                <a href="https://twitter.com/D4rK7355608" target="_blank" rel="noopener noreferrer"
-                    aria-label="Twitter Profile" title="Twitter / X"> <md-icon-button> <md-icon><i
-                                class="fab fa-twitter"></i></md-icon> </md-icon-button> </a>
+                <a href="https://x.com/D4rK7355608" target="_blank" rel="noopener noreferrer"
+                    aria-label="X Profile" title="X"> <md-icon-button> <md-icon><i
+                                class="fab fa-x-twitter"></i></md-icon> </md-icon-button> </a>
                 <a href="https://www.facebook.com/d4rk7355608" target="_blank" rel="noopener noreferrer"
                     aria-label="Facebook Profile" title="Facebook"> <md-icon-button> <md-icon><i
                                 class="fab fa-facebook-f"></i></md-icon> </md-icon-button> </a>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -1,30 +1,13 @@
 <div id="contactPageContainer" class="page-section active">
-        <h1>Contact Us</h1>
-        <form action="#" method="post">
-            <div>
-                <label for="name">Name</label>
-                <input type="text" id="name" name="name" required>
-            </div>
-            <div>
-                <label for="email">Email</label>
-                <input type="email" id="email" name="email" required>
-            </div>
-            <div>
-                <label for="message">Message</label>
-                <textarea id="message" name="message" required></textarea>
-            </div>
-            <button type="submit">Send Message</button>
-        </form>
-        <div class="contact-info">
-            <p>Phone: <a href="tel:+15551234567">+1 (555) 123-4567</a></p>
-            <p>Email: <a href="mailto:info@example.com">info@example.com</a></p>
-            <p>Address: 123 Main Street, Anytown, USA</p>
-        </div>
-        <div class="social-links">
-            <ul>
-                <li><a href="#" aria-label="LinkedIn">LinkedIn</a></li>
-                <li><a href="#" aria-label="GitHub">GitHub</a></li>
-                <li><a href="#" aria-label="Twitter">Twitter</a></li>
-            </ul>
-        </div>
+    <h1>Contact</h1>
+    <div class="contact-info">
+        <p>Email: <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a></p>
     </div>
+    <div class="social-links">
+        <ul>
+            <li><a href="https://github.com/MihaiCristianCondrea" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a></li>
+            <li><a href="https://x.com/D4rK7355608" target="_blank" rel="noopener noreferrer" aria-label="X">X</a></li>
+            <li><a href="https://www.linkedin.com/in/mihai-cristian-condrea/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a></li>
+        </ul>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- keep X and GitHub links from last update
- simplify contact page
- restore dynamic copyright year variable while using new name

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688282d84b4c832d985704b6718cd3fd