### PR TITLE
Standardize hash names for policy pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ pages/
 LICENSE                   # GPLv3 license
 ```
 
+### Hash Fragment Navigation
+
+The router loads pages based on URL fragments (e.g., `#privacy-policy`). Important fragments include:
+
+- `#privacy-policy` – Privacy Policy
+- `#code-of-conduct` – Code of Conduct
+- `#privacy-policy-end-user-software` – Privacy Policy – End-User Software
+- `#terms-of-service-end-user-software` – Terms of Service – End-User Software
+
 ## Running Locally
 
 The project now compiles Tailwind CSS ahead of time. After cloning the repo, install dependencies and run the Tailwind build:

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (navPrivacyPolicyLinkEl) {
         navPrivacyPolicyLinkEl.addEventListener('click', (e) => {
             e.preventDefault();
-            loadPageContent('privacy-policy-website');
+            loadPageContent('privacy-policy');
         });
     }
     if (navSongsLinkEl) {

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -49,7 +49,7 @@ async function loadPageContent(pageId, updateHistory = true) {
         }
     } else {
         switch (pageId) {
-            case 'privacy-policy-website':
+            case 'privacy-policy':
                 pagePath = 'pages/more/privacy-policy.html';
                 pageTitle = 'Privacy Policy';
                 break;
@@ -69,17 +69,17 @@ async function loadPageContent(pageId, updateHistory = true) {
                 pagePath = 'pages/more/apps/legal-notices.html';
                 pageTitle = 'Legal Notices';
                 break;
-            case 'code-of-conduct-website':
+            case 'code-of-conduct':
                 pagePath = 'pages/more/code-of-conduct.html';
                 pageTitle = 'Code of Conduct';
                 break;
-            case 'privacy-policy-apps':
+            case 'privacy-policy-end-user-software':
                 pagePath = 'pages/more/apps/privacy-policy-apps.html';
-                pageTitle = 'Privacy Policy';
+                pageTitle = 'Privacy Policy – End-User Software';
                 break;
-            case 'terms-of-service-apps':
+            case 'terms-of-service-end-user-software':
                 pagePath = 'pages/more/apps/terms-of-service-apps.html';
-                pageTitle = 'Terms of Service';
+                pageTitle = 'Terms of Service – End-User Software';
                 break;
 
             default:

--- a/index.html
+++ b/index.html
@@ -56,10 +56,10 @@
                 </md-list-item>
                 <div class="nested-list" id="moreContent" role="group" aria-hidden="true">
                     <md-list>
-                        <md-list-item href="#privacy-policy-website" id="navPrivacyPolicyLink">
+                        <md-list-item href="#privacy-policy" id="navPrivacyPolicyLink">
                             <div slot="headline">Privacy Policy</div>
                         </md-list-item>
-                        <md-list-item href="#code-of-conduct-website">
+                        <md-list-item href="#code-of-conduct">
                             <div slot="headline">Code of Conduct</div>
                         </md-list-item>
                         <md-list-item href="#contact" id="navContactLink">
@@ -77,10 +77,10 @@
                          <md-list-item href="#ads-help-center" id="navAdsHelpCenterLink">
                             <div slot="headline">Ads Help Center</div>
                         </md-list-item>
-                        <md-list-item href="#privacy-policy-apps">
+                        <md-list-item href="#privacy-policy-end-user-software">
                             <div slot="headline">Privacy Policy</div>
                         </md-list-item>
-                        <md-list-item href="#terms-of-service-apps">
+                        <md-list-item href="#terms-of-service-end-user-software">
                             <div slot="headline">Terms of Service</div>
                         </md-list-item>
                         <md-list-item href="#legal-notices" id="navLegalNoticesLink">

--- a/pages/more/apps/terms-of-service-apps.html
+++ b/pages/more/apps/terms-of-service-apps.html
@@ -7,7 +7,7 @@
          class="page-banner-image">
 
     <p>Welcome to our Android applications (the "App" or "Apps", "Service") provided by <strong>Mihai-Cristian Condrea (operating under the alias "D4rK")</strong> ("we," "us," or "our"). These Terms of Service ("Terms") govern your use of our Apps. Please read them carefully before downloading or using any of our Apps.</p>
-    <p>By downloading, accessing, or using any of our Apps, you agree to be bound by these Terms and our <a href="#privacy-policy-apps">Privacy Policy (Apps)</a>. If you do not agree to these Terms, do not use our Apps.</p>
+    <p>By downloading, accessing, or using any of our Apps, you agree to be bound by these Terms and our <a href="#privacy-policy-end-user-software">Privacy Policy – End-User Software</a>. If you do not agree to these Terms, do not use our Apps.</p>
 
     <md-divider></md-divider>
 
@@ -24,7 +24,7 @@
 
     <h2>3. App Functionality and Updates</h2>
     <p>Mihai-Cristian Condrea (D4rK) is committed to ensuring that the Apps are as useful and efficient as possible. For that reason, we reserve the right to make changes to the Apps or to charge for certain services or features, at any time and for any reason. We will never charge you for an App or its services without making it very clear to you exactly what you’re paying for.</p>
-    <p>Our Apps may store and process personal data as described in our <a href="#privacy-policy-apps">Privacy Policy (Apps)</a> to provide our Service. It’s your responsibility to keep your phone and access to the Apps secure. We therefore recommend that you do not jailbreak or root your phone, which is the process of removing software restrictions and limitations imposed by the official operating system of your device. It could make your phone vulnerable to malware/viruses/malicious programs, compromise your phone’s security features, and it could mean that our Apps won’t work properly or at all.</p>
+    <p>Our Apps may store and process personal data as described in our <a href="#privacy-policy-end-user-software">Privacy Policy – End-User Software</a> to provide our Service. It’s your responsibility to keep your phone and access to the Apps secure. We therefore recommend that you do not jailbreak or root your phone, which is the process of removing software restrictions and limitations imposed by the official operating system of your device. It could make your phone vulnerable to malware/viruses/malicious programs, compromise your phone’s security features, and it could mean that our Apps won’t work properly or at all.</p>
     <p>At some point, we may wish to update an App. The Apps are currently available on Android – the requirements for the system (and for any additional systems we decide to extend the availability of the Apps to) may change, and you’ll need to download the updates if you want to keep using the App. Mihai-Cristian Condrea (D4rK) does not promise that it will always update the Apps so that they are relevant to you and/or work with the Android version that you have installed on your device. However, you promise to always accept updates to the application when offered to you.</p>
 
     <md-divider></md-divider>


### PR DESCRIPTION
## Summary
- rename navigation hashes for privacy policy and code of conduct
- update router cases for new names
- adjust app navigation listener
- fix links in terms-of-service page
- document fragment IDs in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882835aa414832dad2d4673690a6e9b