### PR TITLE
Fix CV page layout

### DIFF
--- a/assets/js/cv.js
+++ b/assets/js/cv.js
@@ -167,7 +167,7 @@ function initialize() {
     addComplexItem('work',{title:'Android Developer',company:'Personal Projects, Bucharest',start:'2020',end:'Current',desc:`- Successfully launched over 10 Android applications, overseeing the entire product lifecycle from UI/UX design and development to publishing.\n- Championed a Google-centric design philosophy, meticulously applying Material Design principles to deliver intuitive and visually consistent applications.`});
     addComplexItem('education',{degree:'Industrial Engineering & Robotics',school:'Polytechnic University of Bucharest',start:'2020',end:'Current'});
     addComplexItem('education',{degree:'High School Diploma, Mathematics-Informatics',school:'"Hristo Botev" Theoretical High School, Bucharest',start:'2016',end:'2020'});
-    document.getElementById('photo-preview').style.backgroundImage = "url('../src/images/cv_profile_pic.png')";
+    document.getElementById('photo-preview').style.backgroundImage = "url('../../assets/images/cv_profile_pic.png')";
 }
 
 function setupMode() {

--- a/pages/cv/index.html
+++ b/pages/cv/index.html
@@ -19,14 +19,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body class="bg-surface-container-lowest">
-    <md-top-app-bar>
-        <a href="/" slot="navigationIcon" aria-label="Back home">
-            <md-icon-button>
-                <md-icon><span class="material-symbols-outlined">arrow_back</span></md-icon>
-            </md-icon-button>
-        </a>
-        <span slot="headline">My CV</span>
-    </md-top-app-bar>
+
 
     <div id="cvPage">
         <div class="form-container">
@@ -86,7 +79,6 @@
                 <button type="button" class="add-btn" onclick="addInterestItem()">Add Interest</button>
             </div>
 
-            <button id="download-cv">Download CV as PDF</button>
         </div>
 
         <div id="cv-preview">
@@ -125,11 +117,10 @@
                 </div>
             </div>
         </div>
+        <div style="width:100%;text-align:center;margin-top:24px;">
+            <button id="download-cv">Download CV as PDF</button>
+        </div>
     </div>
-
-    <footer class="app-footer">
-        <span>&copy; Mihai-Cristian Condrea</span>
-    </footer>
 
     <script src="../../assets/js/cv.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- clean up the CV page so it only displays the final CV and a download button
- fix the profile photo path

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885e823c280832d9531a45cc38e6268