### PR TITLE
Fix CV navigation and manifest

### DIFF
--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -82,9 +82,8 @@ async function loadPageContent(pageId, updateHistory = true) {
                 pageTitle = 'Terms of Service – End-User Software';
                 break;
             case 'cv':
-                pagePath = 'pages/cv/index.html';
-                pageTitle = 'My CV';
-                break;
+                window.location.href = 'pages/cv/index.html';
+                return;
 
             default:
                 console.warn('Router: Unknown page:', pageId);

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Mihai's Profile",
   "short_name": "Mihai",
-  "start_url": "https://d4rk7355608.github.io/profile/#home",
+  "start_url": "./#home",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#3DDC84",

--- a/pages/drawer/contact.html
+++ b/pages/drawer/contact.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="cv-button" style="margin: 16px 0;">
-        <a href="#cv" onclick="loadPageContent('cv'); return false;">
+        <a href="pages/cv/index.html">
             <md-filled-button>
                 <md-icon slot="icon"><span class="material-symbols-outlined">description</span></md-icon>
                 View My CV


### PR DESCRIPTION
## Summary
- update contact page to link directly to the CV page
- redirect `#cv` route to the standalone CV
- fix PWA manifest `start_url`

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885ea43d038832d8fecf4ab1977f7a8