### PR TITLE
Add navigation elements to CV page

### DIFF
--- a/assets/css/cv.css
+++ b/assets/css/cv.css
@@ -1,5 +1,6 @@
 #cvPage {
-    font-family: 'Roboto','Inter',sans-serif;
+    font-family: 'Poppins', sans-serif;
+    margin-top: 70px;
     background-color: var(--app-bg-color);
     color: var(--app-text-color);
     display:flex;
@@ -65,10 +66,10 @@
 #cvPage .contact-info p{display:flex;align-items:center;gap:10px;margin-bottom:12px;word-break:break-all;font-size:14px;}
 #cvPage .contact-info .material-symbols-outlined{font-size:20px;color:var(--md-sys-color-secondary);}
 #cvPage .cv-section{margin-bottom:30px;}
-#cvPage .cv-section h2{font-family:'Inter',sans-serif;font-size:16px;color:#333;margin-bottom:16px;padding-bottom:8px;border-bottom:1.5px solid var(--app-border-color);text-transform:uppercase;letter-spacing:1px;font-weight:700;}
+#cvPage .cv-section h2{font-family:'Poppins',sans-serif;font-size:16px;color:#333;margin-bottom:16px;padding-bottom:8px;border-bottom:1.5px solid var(--app-border-color);text-transform:uppercase;letter-spacing:1px;font-weight:700;}
 #cvPage .cv-right .cv-section h2{border-bottom-color:var(--md-sys-color-primary);}
-#cvPage #cv-name{font-family:'Inter',sans-serif;font-size:36px;font-weight:700;color:#111;margin-bottom:4px;letter-spacing:-0.5px;}
-#cvPage #cv-job-title{font-family:'Inter',sans-serif;font-size:20px;color:var(--md-sys-color-secondary);margin-bottom:24px;font-weight:400;}
+#cvPage #cv-name{font-family:'Poppins',sans-serif;font-size:36px;font-weight:700;color:#111;margin-bottom:4px;letter-spacing:-0.5px;}
+#cvPage #cv-job-title{font-family:'Poppins',sans-serif;font-size:20px;color:var(--md-sys-color-secondary);margin-bottom:24px;font-weight:400;}
 #cvPage #cv-summary{font-size:14px;line-height:1.6;color:#333;margin-bottom:30px;}
 #cvPage .cv-item{margin-bottom:24px;}
 #cvPage .cv-item-header{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:4px;}

--- a/assets/js/cv.js
+++ b/assets/js/cv.js
@@ -181,5 +181,8 @@ document.addEventListener('DOMContentLoaded', () => {
     setupRealtimeUpdates();
     initPdfDownload();
     setupMode();
+    initTheme();
+    initNavigationDrawer();
+    setCopyrightYear();
     document.fonts.ready.then(initialize);
 });

--- a/pages/cv/index.html
+++ b/pages/cv/index.html
@@ -20,6 +20,54 @@
 </head>
 <body class="bg-surface-container-lowest">
 
+    <div id="drawerOverlay" class="drawer-overlay"></div>
+
+    <div id="navDrawer" class="navigation-drawer">
+        <div class="drawer-header">
+            <h2>Menu</h2>
+            <md-icon-button id="closeDrawerButton" aria-label="Close menu">
+                <md-icon><span class="material-symbols-outlined">close</span></md-icon>
+            </md-icon-button>
+        </div>
+        <div class="drawer-content">
+            <md-list>
+                <md-list-item href="../../index.html" id="navHomeLink">
+                    <md-icon slot="start"><span class="material-symbols-outlined">home</span></md-icon>
+                    <div slot="headline">Home</div>
+                </md-list-item>
+                <md-list-item href="https://d4rk7355608.blogspot.com/" target="_blank" rel="noopener noreferrer">
+                    <md-icon slot="start"><span class="material-symbols-outlined">article</span></md-icon>
+                    <div slot="headline">Blogs</div>
+                </md-list-item>
+                <md-divider></md-divider>
+                <md-list-item href="../drawer/contact.html" id="navContactLink">
+                    <md-icon slot="start"><span class="material-symbols-outlined">contact_mail</span></md-icon>
+                    <div slot="headline">Contact</div>
+                </md-list-item>
+            </md-list>
+        </div>
+        <div class="drawer-footer">
+            <div class="theme-toggle-title">Theme</div>
+            <div class="theme-button-container">
+                <md-icon-button id="lightThemeButton" aria-label="Light theme" data-theme="light">
+                    <md-icon><span class="material-symbols-outlined">light_mode</span></md-icon>
+                </md-icon-button>
+                <md-icon-button id="darkThemeButton" aria-label="Dark theme" data-theme="dark">
+                    <md-icon><span class="material-symbols-outlined">dark_mode</span></md-icon>
+                </md-icon-button>
+                <md-icon-button id="autoThemeButton" aria-label="Auto theme" data-theme="auto">
+                    <md-icon><span class="material-symbols-outlined">brightness_auto</span></md-icon>
+                </md-icon-button>
+            </div>
+        </div>
+    </div>
+
+    <md-top-app-bar id="topAppBar">
+        <md-icon-button id="menuButton" slot="navigationIcon" aria-label="Open menu">
+            <md-icon><span class="material-symbols-outlined">menu</span></md-icon>
+        </md-icon-button>
+        <span slot="headline" id="appBarHeadline">Mihai's CV</span>
+    </md-top-app-bar>
 
     <div id="cvPage">
         <div class="form-container">
@@ -122,6 +170,13 @@
         </div>
     </div>
 
+    <footer class="app-footer">
+        <span id="copyright-message"></span>
+    </footer>
+
+    <script src="../../assets/js/utils.js" defer></script>
+    <script src="../../assets/js/theme.js" defer></script>
+    <script src="../../assets/js/navigationDrawer.js" defer></script>
     <script src="../../assets/js/cv.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include top app bar and drawer on CV page
- use Poppins font for all CV elements
- invoke theme and drawer initialization from `cv.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885ec279428832db8d6db58c9b1dd6d