### PR TITLE
Refactor CV PDF generation

### DIFF
--- a/assets/css/cv.css
+++ b/assets/css/cv.css
@@ -59,7 +59,7 @@
 #cvPage .dynamic-list .list-item{display:flex;align-items:center;gap:8px;margin-bottom:8px;}
 #cvPage .dynamic-list .list-item input{flex-grow:1;}
 #cvPage .complex-item-form>div{background-color: var(--md-sys-color-surface-container-low);border:1px solid var(--md-sys-color-surface-variant);padding:16px;border-radius:12px;margin-bottom:16px;display:flex;flex-direction:column;gap:16px;}
-#cvPage #cv-preview{width:800px;background:var(--md-sys-color-surface);box-shadow:0 8px 24px rgba(0,0,0,0.1);border:1px solid var(--app-border-color);height:auto;min-height:auto;}
+#cvPage #cv-preview{width:800px;background:var(--md-sys-color-surface);box-shadow:0 8px 24px rgba(0,0,0,0.1);border:1px solid var(--app-border-color);max-height:1122px;overflow-y:auto;}
 #cvPage .cv-content{display:flex;}
 #cvPage .cv-left{background: var(--md-sys-color-surface-container-high);width:35%;padding:40px 30px;color:#333;}
 #cvPage .cv-right{width:65%;padding:40px 30px;}

--- a/assets/css/print.css
+++ b/assets/css/print.css
@@ -1,0 +1,21 @@
+/* Hide everything by default when printing */
+body * {
+    visibility: hidden;
+}
+
+/* Make only the CV preview and its contents visible */
+#cv-preview, #cv-preview * {
+    visibility: visible;
+}
+
+/* Position the CV preview to take up the entire printed page */
+#cv-preview {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: auto;
+    overflow: visible;
+    box-shadow: none;
+    border: none;
+}

--- a/assets/js/cv.js
+++ b/assets/js/cv.js
@@ -134,35 +134,6 @@ function updateComplexList(sectionId) {
     });
 }
 
-function initPdfDownload() {
-    const btn = document.getElementById('download-cv');
-    if (!btn) return;
-    btn.addEventListener('click', async () => {
-        const cvElement = document.getElementById('cv-preview');
-
-        await document.fonts.ready;
-        const images = Array.from(cvElement.querySelectorAll('img'))
-            .map(img => img.complete ? Promise.resolve() : new Promise(res => { img.onload = img.onerror = res; }));
-        await Promise.all(images);
-
-        const opt = {
-            margin: 0,
-            filename: 'Mihai-Condrea-CV.pdf',
-            image: { type: 'jpeg', quality: 1.0 },
-            html2canvas: {
-                scale: 4,
-                useCORS: true,
-                dpi: 300,
-                letterRendering: true,
-                windowWidth: cvElement.scrollWidth,
-                windowHeight: cvElement.scrollHeight
-            },
-            jsPDF: { unit: 'pt', format: 'a4', orientation: 'portrait' }
-        };
-
-        html2pdf().from(cvElement).set(opt).save();
-    });
-}
 
 function initialize() {
     document.getElementById('name').value = 'Mihai-Cristian Condrea';
@@ -197,7 +168,6 @@ function setupMode() {
 
 document.addEventListener('DOMContentLoaded', () => {
     setupRealtimeUpdates();
-    initPdfDownload();
     setupMode();
     initTheme();
     initNavigationDrawer();

--- a/pages/cv/index.html
+++ b/pages/cv/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="../../assets/css/components.css">
     <link rel="stylesheet" href="../../assets/css/pages.css">
     <link rel="stylesheet" href="../../assets/css/cv.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+    <link rel="stylesheet" href="../../assets/css/print.css" media="print">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body class="bg-surface-container-lowest">
@@ -205,7 +205,7 @@
             </div>
         </div>
         <div style="width:100%;text-align:center;margin-top:24px;">
-            <button id="download-cv"><span class="material-symbols-outlined">download</span><span>Download CV as PDF</span></button>
+            <button onclick="window.print()"><span class="material-symbols-outlined">download</span><span>Download CV as PDF</span></button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- simplify PDF download with browser print dialog
- add print stylesheet for PDF generation
- keep CV preview scrollable using CSS
- remove html2pdf.js dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885f6e7cb74832da85ff820ebbde433