### PR TITLE
Refine UI with Material Web components

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -328,32 +328,10 @@ md-elevated-card.contribute-card {
   top: 0;
   left: 0;
   height: 100vh;
-  width: 300px;
-  background-color: var(--app-drawer-bg-color);
-  color: var(--app-text-color);
-  box-shadow: 4px 0 12px rgba(0, 0, 0, 0.1);
-  transform: translateX(-100%);
-  transition: transform 0.3s ease-in-out, background-color 0.3s ease;
   z-index: 1002;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  border-top-right-radius: 16px;
-  border-bottom-right-radius: 16px;
-}
-
-.navigation-drawer::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: var(--app-drawer-tint-color);
-  opacity: 0.04;
-  pointer-events: none;
-  border-radius: inherit;
-}
-
-.navigation-drawer.open {
-  transform: translateX(0);
+  --md-navigation-drawer-container-width: 300px;
+  --md-navigation-drawer-container-color: var(--app-drawer-bg-color);
+  --md-navigation-drawer-divider-color: var(--app-border-color);
 }
 
 .drawer-overlay {
@@ -626,3 +604,13 @@ md-filled-card.profile-card {
   font-size: 1.3rem;
   color: var(--md-sys-color-primary);
 }
+
+/* --- Scrollbars --- */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background-color: var(--md-sys-color-outline-variant); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background-color: var(--md-sys-color-outline); }
+
+
+md-dialog { --md-dialog-container-color: var(--app-dialog-bg-color); }
+

--- a/assets/js/navigationDrawer.js
+++ b/assets/js/navigationDrawer.js
@@ -20,7 +20,7 @@ function initNavigationDrawer() {
     if (drawerOverlay) drawerOverlay.addEventListener('click', closeDrawer);
 
     document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && navDrawer && navDrawer.classList.contains('open')) {
+        if (event.key === 'Escape' && navDrawer && navDrawer.opened) {
             closeDrawer();
         }
     });
@@ -34,7 +34,7 @@ function initNavigationDrawer() {
  */
 function openDrawer() {
     if (navDrawer && drawerOverlay) {
-        navDrawer.classList.add('open');
+        navDrawer.opened = true;
         drawerOverlay.classList.add('open');
         document.body.classList.add('drawer-is-open');
         if (closeDrawerButton) closeDrawerButton.focus();
@@ -46,7 +46,7 @@ function openDrawer() {
  */
 function closeDrawer() {
     if (navDrawer && drawerOverlay) {
-        navDrawer.classList.remove('open');
+        navDrawer.opened = false;
         drawerOverlay.classList.remove('open');
         document.body.classList.remove('drawer-is-open');
         if (menuButton) menuButton.focus();

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
     <link rel="manifest" href="assets/manifest.json">
     <link rel="stylesheet" href="assets/css/tailwind.css">
     <script type="module" src="https://unpkg.com/@material/web@2.3.0/all.js?module"></script>
+    <script type="module" src="https://unpkg.com/@material/web@2.3.0/labs/navigationdrawer/navigation-drawer.js?module"></script>
+    <script type="module" src="https://unpkg.com/@material/web@2.3.0/dialog/dialog.js?module"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap" rel="stylesheet">
@@ -27,7 +29,7 @@
 
     <div id="drawerOverlay" class="drawer-overlay"></div>
 
-    <div id="navDrawer" class="navigation-drawer">
+    <md-navigation-drawer id="navDrawer" class="navigation-drawer" pivot="start">
         <div class="drawer-header">
             <h2>Menu</h2>
             <md-icon-button id="closeDrawerButton" aria-label="Close menu">
@@ -104,7 +106,7 @@
                 </md-icon-button>
             </div>
         </div>
-    </div>
+    </md-navigation-drawer>
 
     <md-top-app-bar id="topAppBar">
         <md-icon-button id="menuButton" slot="navigationIcon" aria-label="Open menu">

--- a/pages/drawer/contact.html
+++ b/pages/drawer/contact.html
@@ -8,12 +8,10 @@
 
     <div class="contact-info">
         <p>I'll try to respond as soon as possible.</p>
-        <a href="mailto:contact.mihaicristiancondrea@gmail.com">
-            <md-filled-button>
-                <md-icon slot="icon"><span class="material-symbols-outlined">mail</span></md-icon>
-                Email Me
-            </md-filled-button>
-        </a>
+        <md-filled-button id="openContactDialog">
+            <md-icon slot="icon"><span class="material-symbols-outlined">mail</span></md-icon>
+            Email Me
+        </md-filled-button>
     </div>
 
     <div class="availability">
@@ -62,3 +60,19 @@
         </ul>
     </div>
 </div>
+<md-dialog id="contactDialog">
+  <div slot="headline">Contact Mihai</div>
+  <div slot="content">
+    <p>You can reach me at <a href="mailto:contact.mihaicristiancondrea@gmail.com">contact.mihaicristiancondrea@gmail.com</a>.</p>
+  </div>
+  <div slot="actions">
+    <md-text-button dialog-action="close">Close</md-text-button>
+    <md-text-button><a href="mailto:contact.mihaicristiancondrea@gmail.com">Email</a></md-text-button>
+  </div>
+</md-dialog>
+<script>
+  const openBtn = document.getElementById("openContactDialog");
+  const contactDialog = document.getElementById("contactDialog");
+  openBtn?.addEventListener("click", () => { contactDialog.open = true; });
+</script>
+


### PR DESCRIPTION
## Summary
- use `md-navigation-drawer` for the side drawer
- load labs navigation drawer and dialog scripts
- add a Material dialog to the contact page
- update navigation drawer controller logic
- style scrollbars and dialogs via CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888b624f9a0832d947f94a2ca97c666