### PR TITLE
Fix CV page Material drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pages/
       code-of-conduct.html
       apps/               # App specific pages (ads help, legal notices, etc.)
   cv/                     # CV builder module loaded via `#cv`
-    index.html
+    resume.html
 LICENSE                   # GPLv3 license
 ```
 

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -82,7 +82,7 @@ async function loadPageContent(pageId, updateHistory = true) {
                 pageTitle = 'Terms of Service – End-User Software';
                 break;
             case 'cv':
-                window.location.href = 'pages/cv/index.html';
+                window.location.href = 'pages/cv/resume.html';
                 return;
 
             default:

--- a/pages/cv/resume.html
+++ b/pages/cv/resume.html
@@ -22,7 +22,7 @@
 
     <div id="drawerOverlay" class="drawer-overlay"></div>
 
-    <div id="navDrawer" class="navigation-drawer">
+    <md-navigation-drawer id="navDrawer" class="navigation-drawer" pivot="start">
         <div class="drawer-header">
             <h2>Menu</h2>
             <md-icon-button id="closeDrawerButton" aria-label="Close menu">
@@ -99,7 +99,7 @@
                 </md-icon-button>
             </div>
         </div>
-    </div>
+    </md-navigation-drawer>
 
     <md-top-app-bar id="topAppBar">
         <md-icon-button id="menuButton" slot="navigationIcon" aria-label="Open menu">

--- a/pages/drawer/contact.html
+++ b/pages/drawer/contact.html
@@ -19,7 +19,7 @@
     </div>
 
     <div class="cv-button" style="margin: 16px 0;">
-        <a href="pages/cv/index.html">
+        <a href="pages/cv/resume.html">
             <md-filled-button>
                 <md-icon slot="icon"><span class="material-symbols-outlined">description</span></md-icon>
                 View My CV


### PR DESCRIPTION
## Summary
- make router and contact page point to the renamed CV page
- rename `pages/cv/index.html` to `pages/cv/resume.html`
- update README and CV page markup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888bcf2c770832d8fac6440e8e60b8e