### PR TITLE
Add new Projects page and reorder contact item

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ assets/
 pages/
   drawer/                 # Pages accessible from the navigation drawer
     songs.html
+    projects.html
     contact.html
     more/
       privacy-policy.html
@@ -43,6 +44,7 @@ The router loads pages based on URL fragments (e.g., `#privacy-policy`). Importa
 - `#privacy-policy-end-user-software` – Privacy Policy – End-User Software
 - `#terms-of-service-end-user-software` – Terms of Service – End-User Software
 - `#resume` – Resume Builder
+- `#projects` – Showcase of projects
 
 ## Running Locally
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -605,6 +605,51 @@ md-filled-card.profile-card {
   color: var(--md-sys-color-primary);
 }
 
+/* --- Projects Page --- */
+#projectsPageContainer {
+  padding: 1.5rem;
+  background-color: var(--app-card-bg-color);
+  border-radius: 16px;
+  margin-top: 1rem;
+  color: var(--app-text-color);
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.project-card {
+  background-color: var(--app-card-bg-color);
+  border: 1px solid var(--app-border-color);
+  border-radius: 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.project-card img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  background-color: var(--md-sys-color-surface-variant);
+}
+
+.project-card-content {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.project-card-links {
+  margin-top: auto;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
 /* --- Scrollbars --- */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,7 +1,7 @@
 // Global DOM element references needed by multiple modules or for initialization
 let pageContentAreaEl, mainContentPageOriginalEl, appBarHeadlineEl,
-    navHomeLinkEl, navPrivacyPolicyLinkEl, navSongsLinkEl, navContactLinkEl,
-    navResumeLinkEl, topAppBarEl;
+    navHomeLinkEl, navPrivacyPolicyLinkEl, navSongsLinkEl, navProjectsLinkEl,
+    navContactLinkEl, navResumeLinkEl, topAppBarEl;
 
 document.addEventListener('DOMContentLoaded', () => {
     // --- Get DOM Elements ---
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     navHomeLinkEl = getDynamicElement('navHomeLink');
     navPrivacyPolicyLinkEl = getDynamicElement('navPrivacyPolicyLink');
     navSongsLinkEl = getDynamicElement('navSongsLink');
+    navProjectsLinkEl = getDynamicElement('navProjectsLink');
     navContactLinkEl = getDynamicElement('navContactLink');
     navResumeLinkEl = getDynamicElement('navResumeLink');
     topAppBarEl = getDynamicElement('topAppBar');
@@ -46,6 +47,12 @@ document.addEventListener('DOMContentLoaded', () => {
         navSongsLinkEl.addEventListener('click', (e) => {
             e.preventDefault();
             loadPageContent('songs');
+        });
+    }
+    if (navProjectsLinkEl) {
+        navProjectsLinkEl.addEventListener('click', (e) => {
+            e.preventDefault();
+            loadPageContent('projects');
         });
     }
     if (navContactLinkEl) {

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -57,6 +57,10 @@ async function loadPageContent(pageId, updateHistory = true) {
                 pagePath = 'pages/drawer/songs.html';
                 pageTitle = 'My Music';
                 break;
+            case 'projects':
+                pagePath = 'pages/drawer/projects.html';
+                pageTitle = 'Projects';
+                break;
             case 'contact':
                 pagePath = 'pages/drawer/contact.html';
                 pageTitle = 'Contact';

--- a/index.html
+++ b/index.html
@@ -50,6 +50,10 @@
                     <md-icon slot="start"><span class="material-symbols-outlined">music_note</span></md-icon>
                     <div slot="headline">Music</div>
                 </md-list-item>
+                <md-list-item href="#projects" id="navProjectsLink">
+                    <md-icon slot="start"><span class="material-symbols-outlined">work</span></md-icon>
+                    <div slot="headline">Projects</div>
+                </md-list-item>
                 <md-divider></md-divider>
                 <md-list-item type="button" id="moreToggle" aria-controls="moreContent" aria-expanded="false">
                     <md-icon slot="start"><span class="material-symbols-outlined">more_horiz</span></md-icon>
@@ -58,14 +62,14 @@
                 </md-list-item>
                 <div class="nested-list" id="moreContent" role="group" aria-hidden="true">
                     <md-list>
+                        <md-list-item href="#contact" id="navContactLink">
+                            <div slot="headline">Contact</div>
+                        </md-list-item>
                         <md-list-item href="#privacy-policy" id="navPrivacyPolicyLink">
                             <div slot="headline">Privacy Policy</div>
                         </md-list-item>
                         <md-list-item href="#code-of-conduct">
                             <div slot="headline">Code of Conduct</div>
-                        </md-list-item>
-                        <md-list-item href="#contact" id="navContactLink">
-                            <div slot="headline">Contact</div>
                         </md-list-item>
                     </md-list>
                 </div>

--- a/pages/drawer/projects.html
+++ b/pages/drawer/projects.html
@@ -1,0 +1,15 @@
+<div id="projectsPageContainer" class="page-section active">
+    <h1>Projects</h1>
+    <div class="projects-grid">
+        <div class="project-card">
+            <img src="https://via.placeholder.com/300x180.png?text=Project" alt="Profile Website screenshot" loading="lazy">
+            <div class="project-card-content">
+                <h3>Profile Website</h3>
+                <p>This website showcasing my profile and work.</p>
+                <div class="project-card-links">
+                    <a href="https://github.com/MihaiCristianCondrea/profile" target="_blank" rel="noopener noreferrer">GitHub</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add a Projects page with placeholder content
- style projects cards
- link the Projects page in the navigation drawer
- move Contact above Privacy Policy and Code of Conduct
- update router and initialization scripts
- document the new page in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688918774818832db3f65a21d89c0f0d