### PR TITLE
Enhance project showcase with markdown and actions

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -658,6 +658,29 @@ md-filled-card.profile-card {
   text-decoration: underline;
 }
 
+.project-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.project-actions a {
+  text-decoration: none;
+}
+
+@media (max-width: 480px) {
+  .project-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .project-actions a md-filled-button,
+  .project-actions a md-outlined-button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 .carousel {
   position: relative;
   overflow: hidden;

--- a/assets/js/projects.js
+++ b/assets/js/projects.js
@@ -1,0 +1,57 @@
+let markedLoadPromiseProjects;
+
+function ensureProjectsMarkedLoaded() {
+  if (window.marked) return Promise.resolve();
+  if (markedLoadPromiseProjects) return markedLoadPromiseProjects;
+  markedLoadPromiseProjects = new Promise(resolve => {
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/marked/marked.min.js';
+    script.onload = resolve;
+    script.onerror = resolve;
+    document.head.appendChild(script);
+  });
+  return markedLoadPromiseProjects;
+}
+
+function initProjectsPage() {
+  ensureProjectsMarkedLoaded().then(() => {
+    document.querySelectorAll('#projectsPageContainer [data-md]').forEach(el => {
+      if (window.marked) {
+        el.innerHTML = marked.parse(el.textContent.trim());
+      }
+    });
+
+    const tabs = document.querySelectorAll('#projectsFilterTabs md-primary-tab');
+    const projects = document.querySelectorAll('.project-entry');
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        tabs.forEach(t => t.removeAttribute('active'));
+        tab.setAttribute('active', '');
+        const cat = tab.dataset.category;
+        projects.forEach(p => {
+          if (cat === 'all') { p.style.display = ''; return; }
+          p.style.display = p.dataset.category.includes(cat) ? '' : 'none';
+        });
+      });
+    });
+
+    document.querySelectorAll('.carousel').forEach(carousel => {
+      const slides = carousel.querySelectorAll('.carousel-slide');
+      let index = 0;
+      const update = () => slides.forEach((s,i) => s.classList.toggle('active', i===index));
+      update();
+      carousel.querySelector('.prev').addEventListener('click', () => {
+        index = (index - 1 + slides.length) % slides.length; update();
+      });
+      carousel.querySelector('.next').addEventListener('click', () => {
+        index = (index + 1) % slides.length; update();
+      });
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (document.getElementById('projectsPageContainer')) {
+    initProjectsPage();
+  }
+});

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -115,6 +115,8 @@ async function loadPageContent(pageId, updateHistory = true) {
                 loadSongs();
             } else if (pageId === 'resume' && typeof initResumePage === 'function') {
                 initResumePage();
+            } else if (pageId === 'projects' && typeof initProjectsPage === 'function') {
+                initProjectsPage();
             }
         } catch (error) {
             console.error(`Error loading ${pageTitle}:`, error);

--- a/index.html
+++ b/index.html
@@ -244,6 +244,7 @@
     <script src="assets/js/bloggerApi.js" defer></script>
     <script src="assets/js/resume.js" defer></script>
     <script src="assets/js/songs.js" defer></script>
+    <script src="assets/js/projects.js" defer></script>
     <script src="assets/js/router.js" defer></script>
     <script src="assets/js/app.js" defer></script>
 

--- a/pages/drawer/projects.html
+++ b/pages/drawer/projects.html
@@ -12,14 +12,20 @@
         <div class="project-info">
           <h2>Profile Website</h2>
           <div class="date-range">2023&nbsp;&ndash;&nbsp;Present</div>
-          <p>This website showcasing my profile and work. View the source on
-            <a href="https://github.com/MihaiCristianCondrea/profile" target="_blank" rel="noopener noreferrer">GitHub</a>.
-          </p>
+          <div class="project-description" data-md>
+This website showcasing my profile and work. View the source on [GitHub](https://github.com/MihaiCristianCondrea/profile).
+          </div>
+          <div class="project-actions">
+            <a href="https://github.com/MihaiCristianCondrea/profile" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>See Code</md-filled-button>
+            </a>
+          </div>
         </div>
         <div class="project-media">
           <div class="carousel">
             <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Website+1" alt="Profile Website screenshot" loading="lazy">
             <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Website+2" alt="Profile Website screenshot 2" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Website+3" alt="Profile Website screenshot 3" loading="lazy">
             <button class="prev" aria-label="Previous">
               <span class="material-symbols-outlined">chevron_left</span>
             </button>
@@ -35,11 +41,23 @@
         <div class="project-info">
           <h2>AppToolkit for Android</h2>
           <div class="date-range">2025&nbsp;&ndash;&nbsp;Present</div>
-          <p>A showcase of the reusable components, screens, and architecture used across my applications. It serves as a live demo, featuring Jetpack Compose UI, Material You theming, and modern fade-through screen transitions.</p>
+          <div class="project-description" data-md>
+A showcase of the reusable components, screens, and architecture used across my applications. It serves as a live demo, featuring Jetpack Compose UI, Material You theming, and modern fade-through screen transitions.
+          </div>
+          <div class="project-actions">
+            <a href="https://play.google.com/store/apps/details?id=com.example.apptoolkit" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>Install App</md-filled-button>
+            </a>
+            <a href="https://github.com/MihaiCristianCondrea/apptoolkit" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>See Code</md-filled-button>
+            </a>
+          </div>
         </div>
         <div class="project-media">
           <div class="carousel">
-            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="AppToolkit screenshot" loading="lazy">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project+1" alt="AppToolkit screenshot" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+2" alt="AppToolkit screenshot 2" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+3" alt="AppToolkit screenshot 3" loading="lazy">
             <button class="prev" aria-label="Previous">
               <span class="material-symbols-outlined">chevron_left</span>
             </button>
@@ -55,11 +73,23 @@
         <div class="project-info">
           <h2>Android Studio Tutorials</h2>
           <div class="date-range">2022&nbsp;&ndash;&nbsp;Present</div>
-          <p>A pair of educational apps designed to teach beginners Android development with either Java or Kotlin/XML. The tutorials are available offline and include code snippets, ready-to-use layouts, and an AI Companion for assistance.</p>
+          <div class="project-description" data-md>
+A pair of educational apps designed to teach beginners Android development with either Java or Kotlin/XML. The tutorials are available offline and include code snippets, ready-to-use layouts, and an AI Companion for assistance.
+          </div>
+          <div class="project-actions">
+            <a href="https://play.google.com/store/apps/details?id=com.example.tutorials" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>Install App</md-filled-button>
+            </a>
+            <a href="https://github.com/MihaiCristianCondrea/android-studio-tutorials" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>See Code</md-filled-button>
+            </a>
+          </div>
         </div>
         <div class="project-media">
           <div class="carousel">
-            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="Android Studio Tutorials screenshot" loading="lazy">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project+1" alt="Android Studio Tutorials screenshot" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+2" alt="Android Studio Tutorials screenshot 2" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+3" alt="Android Studio Tutorials screenshot 3" loading="lazy">
             <button class="prev" aria-label="Previous">
               <span class="material-symbols-outlined">chevron_left</span>
             </button>
@@ -75,11 +105,23 @@
         <div class="project-info">
           <h2>Smart Cleaner for Android</h2>
           <div class="date-range">2021&nbsp;&ndash;&nbsp;Present</div>
-          <p>A utility app providing a one-tap solution for freeing up device space and managing performance. It is a free, ad-supported tool for Android 8.0+ devices.</p>
+          <div class="project-description" data-md>
+A utility app providing a one-tap solution for freeing up device space and managing performance. It is a free, ad-supported tool for Android 8.0+ devices.
+          </div>
+          <div class="project-actions">
+            <a href="https://play.google.com/store/apps/details?id=com.d4rk.cleaner" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>Install App</md-filled-button>
+            </a>
+            <a href="https://github.com/MihaiCristianCondrea/cleaner" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>See Code</md-filled-button>
+            </a>
+          </div>
         </div>
         <div class="project-media">
           <div class="carousel">
-            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="Smart Cleaner screenshot" loading="lazy">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project+1" alt="Smart Cleaner screenshot" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+2" alt="Smart Cleaner screenshot 2" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+3" alt="Smart Cleaner screenshot 3" loading="lazy">
             <button class="prev" aria-label="Previous">
               <span class="material-symbols-outlined">chevron_left</span>
             </button>
@@ -95,11 +137,23 @@
         <div class="project-info">
           <h2>Weddix – Create/Manage Events</h2>
           <div class="date-range">2024&nbsp;&ndash;&nbsp;Present</div>
-          <p>An event-planning tool designed to make organizing a wedding or other event simple and stress-free. It helps users manage guest lists, track tasks, and control budgets with an intuitive drag-and-drop interface.</p>
+          <div class="project-description" data-md>
+An event-planning tool designed to make organizing a wedding or other event simple and stress-free. It helps users manage guest lists, track tasks, and control budgets with an intuitive drag-and-drop interface.
+          </div>
+          <div class="project-actions">
+            <a href="https://play.google.com/store/apps/details?id=com.example.weddix" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>Install App</md-filled-button>
+            </a>
+            <a href="https://github.com/MihaiCristianCondrea/weddix" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>See Code</md-filled-button>
+            </a>
+          </div>
         </div>
         <div class="project-media">
           <div class="carousel">
-            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="Weddix screenshot" loading="lazy">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project+1" alt="Weddix screenshot" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+2" alt="Weddix screenshot 2" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+3" alt="Weddix screenshot 3" loading="lazy">
             <button class="prev" aria-label="Previous">
               <span class="material-symbols-outlined">chevron_left</span>
             </button>
@@ -115,11 +169,23 @@
         <div class="project-info">
           <h2>Collection of Utility Apps</h2>
           <div class="date-range">2022&nbsp;&ndash;&nbsp;Present</div>
-          <p>A suite of small, functional apps to solve everyday problems. This collection includes the Shopping Cart Calculator, Low Brightness screen dimmer, Music Sleep Timer Plus, the versatile QR &amp; Bar Code Scanner Plus, and the Net Probe network tool.</p>
+          <div class="project-description" data-md>
+A suite of small, functional apps to solve everyday problems. This collection includes the Shopping Cart Calculator, Low Brightness screen dimmer, Music Sleep Timer Plus, the versatile QR & Bar Code Scanner Plus, and the Net Probe network tool.
+          </div>
+          <div class="project-actions">
+            <a href="https://play.google.com/store/apps/dev?id=5390214922640123642" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>Install App</md-filled-button>
+            </a>
+            <a href="https://github.com/MihaiCristianCondrea" target="_blank" rel="noopener noreferrer">
+              <md-filled-button>See Code</md-filled-button>
+            </a>
+          </div>
         </div>
         <div class="project-media">
           <div class="carousel">
-            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project" alt="Collection of Utility Apps screenshot" loading="lazy">
+            <img class="carousel-slide active" src="https://via.placeholder.com/600x400.png?text=Project+1" alt="Collection of Utility Apps screenshot" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+2" alt="Collection of Utility Apps screenshot 2" loading="lazy">
+            <img class="carousel-slide" src="https://via.placeholder.com/600x400.png?text=Project+3" alt="Collection of Utility Apps screenshot 3" loading="lazy">
             <button class="prev" aria-label="Previous">
               <span class="material-symbols-outlined">chevron_left</span>
             </button>
@@ -132,34 +198,4 @@
     </md-filled-card>
   </div>
 </div>
-<script>
-(() => {
-  const tabs = document.querySelectorAll('#projectsFilterTabs md-primary-tab');
-  const projects = document.querySelectorAll('.project-entry');
-  tabs.forEach(tab => {
-    tab.addEventListener('click', () => {
-      tabs.forEach(t => t.removeAttribute('active'));
-      tab.setAttribute('active', '');
-      const cat = tab.dataset.category;
-      projects.forEach(p => {
-        if (cat === 'all') { p.style.display = ''; return; }
-        p.style.display = p.dataset.category.includes(cat) ? '' : 'none';
-      });
-    });
-  });
-
-  document.querySelectorAll('.carousel').forEach(carousel => {
-    const slides = carousel.querySelectorAll('.carousel-slide');
-    let index = 0;
-    const update = () => slides.forEach((s,i) => s.classList.toggle('active', i===index));
-    update();
-    carousel.querySelector('.prev').addEventListener('click', () => {
-      index = (index - 1 + slides.length) % slides.length; update();
-    });
-    carousel.querySelector('.next').addEventListener('click', () => {
-      index = (index + 1) % slides.length; update();
-    });
-  });
-})();
-</script>
 


### PR DESCRIPTION
## Summary
- enable Markdown rendering for project descriptions
- add install and source code buttons on project cards
- show carousels with three placeholder images each
- initialize projects page with new JS module
- style project action buttons

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tailwindcss -i ./assets/css/tailwind.input.css -o ./assets/css/tailwind.css --minify`


------
https://chatgpt.com/codex/tasks/task_e_6889efbe5cd8832d98aedc519d2c48b1