### PR TITLE
Fix navigation drawer initialization

### DIFF
--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -45,6 +45,7 @@ function setCopyrightYear() {
         const yearText = currentYear === 2025 ? '2025' : `2025-${currentYear}`;
         copyrightElement.textContent = `Copyright © ${yearText}, Mihai-Cristian Condrea`;
     }
+}
 
 
 /** Show page loading overlay */


### PR DESCRIPTION
## Summary
- close `setCopyrightYear` function properly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a15f1c588832db06456c0fe09f91c