### PR TITLE
Update drawer labels and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source for a personal profile site built as a small
 ## Features
 
 - **Material Design Components** – UI is styled with Google's Material Web Components.
-- **Navigation Drawer** – A slide‑out drawer lists Home, Blogs, Music, Projects and collapsible "About" and "Android Apps" sections.
+- **Navigation Drawer** – A slide‑out drawer lists Home, Blogs, Music, Projects and collapsible "Profile" and "Android Apps" sections.
 - **Light/Dark Theme** – A theme toggle stores your preference in `localStorage` and can automatically match the system theme.
 - **Blogger Integration** – The home page fetches recent blog posts from Blogger using the Blogger API.
 - **Client‑Side Routing** – JavaScript loads internal pages without a full reload (privacy policy, code of conduct, app related info, etc.).
@@ -41,7 +41,7 @@ LICENSE                   # GPLv3 license
 
 The router loads pages based on URL fragments (e.g., `#privacy-policy`). Important fragments include:
 
-- `#privacy-policy` – Privacy & Cookies
+- `#privacy-policy` – Privacy Policy
 - `#code-of-conduct` – Code of Conduct
 - `#privacy-policy-end-user-software` – Privacy Policy – End-User Software
 - `#terms-of-service-end-user-software` – Terms of Service – End-User Software

--- a/index.html
+++ b/index.html
@@ -57,12 +57,12 @@
                     <div slot="headline">Projects</div>
                 </md-list-item>
                 <md-divider></md-divider>
-                <md-list-item type="button" id="aboutToggle" aria-controls="aboutContent" aria-expanded="false">
+                <md-list-item type="button" id="aboutToggle" aria-controls="aboutContent" aria-expanded="true" class="expanded">
                     <md-icon slot="start"><span class="material-symbols-outlined">info</span></md-icon>
-                    <div slot="headline">About</div>
+                    <div slot="headline">Profile</div>
                     <md-icon slot="end"><span class="material-symbols-outlined">expand_more</span></md-icon>
                 </md-list-item>
-                <div class="nested-list" id="aboutContent" role="group" aria-hidden="true">
+                <div class="nested-list open" id="aboutContent" role="group" aria-hidden="false">
                     <md-list>
                         <md-list-item href="#contact" id="navContactLink">
                             <div slot="headline">Contact</div>
@@ -70,33 +70,30 @@
                         <md-list-item href="#about-me" id="navAboutMeLink">
                             <div slot="headline">About Me</div>
                         </md-list-item>
-                        <md-list-item href="#privacy-policy" id="navPrivacyPolicyLink">
-                            <div slot="headline">Privacy &amp; Cookies</div>
-                        </md-list-item>
                         <md-list-item href="#code-of-conduct">
                             <div slot="headline">Code of Conduct</div>
                         </md-list-item>
                     </md-list>
                 </div>
                 <md-divider></md-divider>
-                <md-list-item type="button" id="androidAppsToggle" aria-controls="androidAppsContent" aria-expanded="false">
+                <md-list-item type="button" id="androidAppsToggle" aria-controls="androidAppsContent" aria-expanded="true" class="expanded">
                     <md-icon slot="start"><span class="material-symbols-outlined">apps</span></md-icon>
                     <div slot="headline">Android Apps</div>
                     <md-icon slot="end"><span class="material-symbols-outlined">expand_more</span></md-icon>
                 </md-list-item>
-                <div class="nested-list" id="androidAppsContent" role="group" aria-hidden="true">
+                <div class="nested-list open" id="androidAppsContent" role="group" aria-hidden="false">
                     <md-list>
                          <md-list-item href="#ads-help-center" id="navAdsHelpCenterLink">
                             <div slot="headline">Ads Help Center</div>
                         </md-list-item>
                         <md-list-item href="#privacy-policy-end-user-software">
-                            <div slot="headline">App Privacy</div>
+                            <div slot="headline">Privacy Policy</div>
                         </md-list-item>
                         <md-list-item href="#terms-of-service-end-user-software">
                             <div slot="headline">Terms of Service</div>
                         </md-list-item>
                         <md-list-item href="#legal-notices" id="navLegalNoticesLink">
-                            <div slot="headline">Legal Info</div>
+                            <div slot="headline">Legal Notices</div>
                         </md-list-item>
                     </md-list>
                 </div>
@@ -116,7 +113,13 @@
                     <md-icon><span class="material-symbols-outlined">brightness_auto</span></md-icon>
                 </md-icon-button>
             </div>
-            <div class="text-center text-gray-500 text-sm mt-2">Privacy &amp; Cookies &bull; Code of Conduct</div>
+            <div class="text-center text-gray-500 text-xs mt-2">
+                <a href="#privacy-policy" class="underline">Privacy Policy</a>
+                &bull;
+                <a href="#terms-of-service-end-user-software" class="underline">Terms of Service</a>
+                &bull;
+                <a href="#code-of-conduct" class="underline">Code of Conduct</a>
+            </div>
         </div>
     </md-navigation-drawer>
     </nav>


### PR DESCRIPTION
## Summary
- rename 'About' tab to 'Profile'
- rename 'Legal Info' to 'Legal Notices' in Android Apps
- rename 'App Privacy' to 'Privacy Policy'
- expand menu sections by default
- add footer links to Privacy Policy and Terms of Service
- update README navigation docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a19cb6ed8832d98ba6ea5593445d3