### PR TITLE
Add carousel loading animation

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -743,6 +743,17 @@ md-filled-card.profile-card {
   opacity: 1;
 }
 
+/* Loading overlay for carousels */
+.carousel-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--app-bg-color);
+  z-index: 1;
+}
+
 /* --- Scrollbars --- */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/assets/js/projects.js
+++ b/assets/js/projects.js
@@ -37,7 +37,36 @@ function initProjectsPage() {
 
     document.querySelectorAll('.carousel').forEach(carousel => {
       const slides = carousel.querySelectorAll('.carousel-slide');
+      const prevBtn = carousel.querySelector('.prev');
+      const nextBtn = carousel.querySelector('.next');
       let index = 0;
+
+      // Add loading animation overlay
+      const loading = document.createElement('div');
+      loading.classList.add('carousel-loading');
+      const loader = document.createElement('lottie-player');
+      loader.src = 'assets/images/lottie/anim_infinite_loop.lottie';
+      loader.setAttribute('autoplay', '');
+      loader.setAttribute('loop', '');
+      loading.appendChild(loader);
+      carousel.appendChild(loading);
+
+      let loadedCount = 0;
+      const hideLoading = () => {
+        loadedCount++;
+        if (loadedCount === slides.length) {
+          loading.remove();
+        }
+      };
+
+      slides.forEach(img => {
+        if (img.complete) {
+          hideLoading();
+        } else {
+          img.addEventListener('load', hideLoading);
+          img.addEventListener('error', hideLoading);
+        }
+      });
 
       const dotsContainer = document.createElement('div');
       dotsContainer.classList.add('carousel-dots');
@@ -56,10 +85,16 @@ function initProjectsPage() {
       };
       update();
 
-      carousel.querySelector('.prev').addEventListener('click', () => {
+      if (slides.length < 2) {
+        prevBtn.style.display = 'none';
+        nextBtn.style.display = 'none';
+        dotsContainer.style.display = 'none';
+      }
+
+      prevBtn.addEventListener('click', () => {
         index = (index - 1 + slides.length) % slides.length; update();
       });
-      carousel.querySelector('.next').addEventListener('click', () => {
+      nextBtn.addEventListener('click', () => {
         index = (index + 1) % slides.length; update();
       });
     });

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png">
     <link rel="manifest" href="assets/manifest.json">
     <link rel="stylesheet" href="assets/css/tailwind.css">
+    <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
     <script type="module" src="https://unpkg.com/@material/web@2.3.0/all.js?module"></script>
     <script type="module" src="https://unpkg.com/@material/web@2.3.0/labs/navigationdrawer/navigation-drawer.js?module"></script>
     <script type="module" src="https://unpkg.com/@material/web@2.3.0/dialog/dialog.js?module"></script>


### PR DESCRIPTION
## Summary
- load Lottie player for carousel animations
- show a single infinite-loop Lottie while project carousel images load
- add CSS for carousel loading overlay and hide controls when only one image

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688bbad53640832da29308ef706a1477