### PR TITLE
Fix project loaders and placeholder image

### DIFF
--- a/assets/js/projects.js
+++ b/assets/js/projects.js
@@ -44,7 +44,7 @@ function initProjectsPage() {
       const loading = document.createElement('div');
       loading.classList.add('carousel-loading');
       const loader = document.createElement('lottie-player');
-      loader.src = 'assets/images/lottie/anim_infinite_loop.json';
+      loader.setAttribute('src', 'assets/images/lottie/anim_infinite_loop.json');
       loader.setAttribute('autoplay', '');
       loader.setAttribute('loop', '');
       loader.style.width = '80px';

--- a/pages/drawer/projects.html
+++ b/pages/drawer/projects.html
@@ -87,7 +87,7 @@ A pair of educational apps designed to teach beginners Android development with 
         </div>
         <div class="project-media">
           <div class="carousel">
-            <img class="carousel-slide active" src="https://via.placeholder.com/800x450.png?text=Project+1" alt="Android Studio Tutorials screenshot" loading="lazy">
+            <img class="carousel-slide active" src="assets/images/placeholder.png" alt="Android Studio Tutorials screenshot" loading="lazy">
             <img class="carousel-slide" src="assets/images/placeholder.png" alt="Android Studio Tutorials screenshot 2" loading="lazy">
             <img class="carousel-slide" src="assets/images/placeholder.png" alt="Android Studio Tutorials screenshot 3" loading="lazy">
             <button class="prev" aria-label="Previous">


### PR DESCRIPTION
## Summary
- use local placeholder image for the first project carousel
- set lottie loader src using attribute to avoid error

## Testing
- `npx tailwindcss -i ./assets/css/tailwind.input.css -o ./assets/css/tailwind.css --minify`

------
https://chatgpt.com/codex/tasks/task_e_688c56612ea8832dbd597d812014ba43