### PR TITLE
Add DotLottie loader and placeholder fallback

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -770,6 +770,28 @@ md-filled-card.profile-card {
   align-items: center;
   background-color: var(--app-bg-color);
   z-index: 1;
+  transition: opacity 0.5s;
+}
+
+.carousel-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--app-bg-color);
+  opacity: 0;
+  border-radius: 12px;
+  z-index: 1;
+  transition: opacity 0.5s;
+}
+
+.carousel-placeholder.show {
+  opacity: 1;
+}
+
+.fade-out {
+  opacity: 0;
 }
 
 /* --- Scrollbars --- */

--- a/assets/js/projects.js
+++ b/assets/js/projects.js
@@ -43,20 +43,49 @@ function initProjectsPage() {
 
       const loading = document.createElement('div');
       loading.classList.add('carousel-loading');
-      const loader = document.createElement('lottie-player');
-      loader.setAttribute('src', 'assets/images/lottie/anim_infinite_loop.json');
+      const loader = document.createElement('dotlottie-wc');
+      loader.setAttribute('src', 'https://lottie.host/ed183b18-bffe-4e7f-a222-d554908e33b8/FhsNasBleM.lottie');
       loader.setAttribute('autoplay', '');
       loader.setAttribute('loop', '');
+      loader.setAttribute('speed', '1');
       loader.style.width = '80px';
       loader.style.height = '80px';
       loading.appendChild(loader);
       carousel.appendChild(loading);
 
+      const placeholder = document.createElement('div');
+      placeholder.classList.add('carousel-placeholder');
+      const placeholderImg = document.createElement('img');
+      placeholderImg.src = 'assets/images/placeholder.png';
+      placeholder.appendChild(placeholderImg);
+      carousel.appendChild(placeholder);
+
+      const startTime = Date.now();
+      const minDisplay = 2000;
+      const placeholderDelay = 4000;
+      const hideLoadingOverlay = () => {
+        const elapsed = Date.now() - startTime;
+        const delay = Math.max(0, minDisplay - elapsed);
+        setTimeout(() => {
+          loading.classList.add('fade-out');
+          setTimeout(() => loading.remove(), 500);
+          placeholder.classList.add('fade-out');
+          setTimeout(() => placeholder.remove(), 500);
+          clearTimeout(placeholderTimer);
+        }, delay);
+      };
+
+      const placeholderTimer = setTimeout(() => {
+        loading.classList.add('fade-out');
+        setTimeout(() => loading.remove(), 500);
+        placeholder.classList.add('show');
+      }, placeholderDelay);
+
       let loadedCount = 0;
       const hideLoading = () => {
         loadedCount++;
         if (loadedCount === slides.length) {
-          loading.remove();
+          hideLoadingOverlay();
         }
       };
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png">
     <link rel="manifest" href="assets/manifest.json">
     <link rel="stylesheet" href="assets/css/tailwind.css">
-    <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+    <script src="https://unpkg.com/@lottiefiles/dotlottie-wc@0.6.2/dist/dotlottie-wc.js" type="module"></script>
     <script type="module" src="https://unpkg.com/@material/web@2.3.0/all.js?module"></script>
     <script type="module" src="https://unpkg.com/@material/web@2.3.0/labs/navigationdrawer/navigation-drawer.js?module"></script>
     <script type="module" src="https://unpkg.com/@material/web@2.3.0/dialog/dialog.js?module"></script>


### PR DESCRIPTION
## Summary
- replace lottie-player with dotLottie runtime
- add carousel placeholder and animation timing
- style placeholder and fade transitions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c5e3f3a2c832da5a886345e6e0e16