### PR TITLE
Add lazy loading to profile avatar

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
             <md-filled-card class="profile-card">
                 <div class="card-content">
                     <div class="profile-header">
-                        <img src="https://avatars.githubusercontent.com/u/61864357?v=4"
+                        <img src="https://avatars.githubusercontent.com/u/61864357?v=4" loading="lazy"
                             alt="Mihai-Cristian Condrea Profile Picture" class="profile-avatar"
                             onerror="this.style.backgroundColor='#e0e0e0'; this.src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';">
                         <div class="profile-info">


### PR DESCRIPTION
## Summary
- Load profile avatar lazily to improve page performance

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6897d7d315f0832d864e4a6b261f3cc9