### PR TITLE
chore: defer loading for static images

### DIFF
--- a/pages/drawer/more/apps/ads-help-center.html
+++ b/pages/drawer/more/apps/ads-help-center.html
@@ -2,7 +2,7 @@
     <h1>Understanding Advertising in My Applications</h1>
 
     <img src="assets/images/banners/privacy_and_ads_banner.png"
-        alt="Illustration representing advertising and user privacy controls" class="page-banner-image">
+        alt="Illustration representing advertising and user privacy controls" class="page-banner-image" loading="lazy">
 
     <h2 id="introduction">Introduction</h2>
     <p>My commitment to transparency, accountability, and respect for user autonomy is central to the way I design and operate my applications. Advertising plays an essential role in ensuring that my products remain freely available while supporting the ongoing development, maintenance, and improvement of my services. This page provides a clear and comprehensive explanation of my advertising practices, the choices available to you, and the safeguards I apply to uphold your privacy and regulatory rights.</p>

--- a/pages/drawer/more/apps/privacy-policy-apps.html
+++ b/pages/drawer/more/apps/privacy-policy-apps.html
@@ -4,7 +4,7 @@
 
     <img src="assets/images/privacy/app_privacy_banner_shield.png"
          alt="Illustration of a shield representing app data privacy and security"
-         class="page-banner-image">
+         class="page-banner-image" loading="lazy">
 
     <p>This Privacy Policy governs the manner in which <strong>Mihai-Cristian Condrea</strong> ("I," "me," or "my") collects, uses, maintains, and discloses information collected from users (each, a "User") of my Android applications (the "Service" or "Apps"). This privacy policy applies to all applications offered by <strong>Mihai-Cristian Condrea </strong>.</p>
     <p>By using my Apps, you signify your acceptance of this policy. If you do not agree to this policy, please do not use my Apps. Your continued use of the Apps following the posting of changes to this policy will be deemed your acceptance of those changes.</p>
@@ -27,7 +27,7 @@
 
     <img src="assets/images/privacy/data_analytics_privacy_banner.png"
          alt="Abstract illustration of data analytics and privacy considerations"
-         class="page-banner-image">
+         class="page-banner-image" loading="lazy">
 
     <md-divider></md-divider>
 
@@ -73,7 +73,7 @@
 
     <img src="assets/images/privacy/user_control_privacy_banner.png"
          alt="Illustration depicting user control over privacy settings"
-         class="page-banner-image">
+         class="page-banner-image" loading="lazy">
 
     <md-divider></md-divider>
 

--- a/pages/drawer/more/apps/terms-of-service-apps.html
+++ b/pages/drawer/more/apps/terms-of-service-apps.html
@@ -4,7 +4,7 @@
 
     <img src="assets/images/legal/terms_service_banner_agreement.png"
          alt="Illustration of a document or handshake representing agreement to terms"
-         class="page-banner-image">
+         class="page-banner-image" loading="lazy">
 
     <p>Welcome to my Android applications (the "App" or "Apps", "Service") provided by <strong>Mihai-Cristian Condrea</strong> ("I," "me," or "my"). These Terms of Service ("Terms") govern your use of my Apps. Please read them carefully before downloading or using any of my Apps.</p>
     <p>By downloading, accessing, or using any of my Apps, you agree to be bound by these Terms and my <a href="#privacy-policy-end-user-software">Privacy Policy – End-User Software</a>. If you do not agree to these Terms, do not use my Apps.</p>
@@ -49,7 +49,7 @@
 
     <img src="assets/images/mobile/in_app_purchase_banner.png"
          alt="Illustration related to in-app purchases or digital transactions"
-         class="page-banner-image">
+         class="page-banner-image" loading="lazy">
 
     <md-divider></md-divider>
 

--- a/pages/drawer/more/code-of-conduct.html
+++ b/pages/drawer/more/code-of-conduct.html
@@ -2,8 +2,8 @@
     <h1>Code of Conduct</h1>
     <p class="last-updated-text">Effective Date: July 25, 2025</p>
 
-    <img src="assets/images/legal/code_of_conduct_banner.png" 
-        alt="Illustration representing respectful interaction" class="page-banner-image">
+    <img src="assets/images/legal/code_of_conduct_banner.png"
+        alt="Illustration representing respectful interaction" class="page-banner-image" loading="lazy">
 
     <p>As the creator and maintainer of this website and associated projects, I am committed to fostering a positive, respectful, and harassment-free environment for everyone who interacts with my work or with me directly. This Code of Conduct outlines my expectations for behavior and my pledge to uphold these standards.</p>
     <p>This applies to interactions related to this website, my open-source projects, communications via email, and any other spaces where I represent myself professionally.</p>

--- a/pages/drawer/more/privacy-policy.html
+++ b/pages/drawer/more/privacy-policy.html
@@ -3,7 +3,7 @@
     <p class="last-updated-text">Last updated: July 25, 2025</p>
 
    <img src="assets/images/privacy/privacy_banner_friendly_guardian.png"
-        alt="Illustration of a friendly guardian representing data privacy">
+        alt="Illustration of a friendly guardian representing data privacy" loading="lazy">
 
     <p>Welcome to Mihai's Profile Website ("me", "I", or "my"). I am committed to protecting your privacy. This Privacy Policy explains how I collect, use, disclose, and safeguard your information when you visit my website (the "Service"). Please read this privacy policy carefully. If you do not agree with the terms of this privacy policy, please do not access the site.</p>
     <p>I reserve the right to make changes to this Privacy Policy at any time and for any reason. I will alert you about any changes by updating the "Last updated" date of this Privacy Policy. You are encouraged to periodically review this Privacy Policy to stay informed of updates.</p>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to static images under pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898a4b85ccc832db298bf6f6e75e2e1