### PR TITLE
Expand about page with detailed profile

### DIFF
--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -1012,3 +1012,84 @@
   font-weight: 500;
   text-align: left;
 }
+/* --- About Me Page Specific Styles --- */
+#aboutMePageContainer {
+  background-color: var(--app-card-bg-color);
+  border-radius: 16px;
+  padding: 1.75rem 2rem;
+  margin-top: 1.5rem;
+  color: var(--app-text-color);
+}
+
+#aboutMePageContainer h1 {
+  font-size: 1.75rem;
+  font-weight: 500;
+  margin: 0 0 1.5rem 0;
+  color: var(--app-text-color);
+}
+
+#aboutMePageContainer p {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--app-text-color);
+  margin-bottom: 1rem;
+}
+
+#aboutMePageContainer .about-summary {
+  font-size: 1.05rem;
+  color: var(--app-text-color);
+  margin-bottom: 1.75rem;
+}
+
+#aboutMePageContainer .about-section {
+  margin-top: 2rem;
+}
+
+#aboutMePageContainer .about-section:first-of-type {
+  margin-top: 1.5rem;
+}
+
+#aboutMePageContainer .about-section ul {
+  list-style: disc;
+  margin: 0;
+  padding-left: 1.75rem;
+}
+
+#aboutMePageContainer .about-section li {
+  margin-bottom: 0.75rem;
+  line-height: 1.7;
+  color: var(--app-text-color);
+}
+
+#aboutMePageContainer .about-section li strong {
+  color: var(--app-text-color);
+  font-weight: 600;
+}
+
+#aboutMePageContainer .about-section a {
+  color: var(--md-sys-color-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+#aboutMePageContainer .about-section a:hover,
+#aboutMePageContainer .about-section a:focus {
+  text-decoration: underline;
+  outline: none;
+}
+
+#aboutMePageContainer .profile-card-actions {
+  margin-top: 2.5rem;
+  padding: 0.75rem 0 0 0;
+  border-top: 1px solid var(--app-border-color);
+}
+
+@media (max-width: 600px) {
+  #aboutMePageContainer {
+    padding: 1.5rem;
+  }
+
+  #aboutMePageContainer .about-summary {
+    font-size: 1rem;
+  }
+}

--- a/pages/drawer/about-me.html
+++ b/pages/drawer/about-me.html
@@ -1,4 +1,70 @@
 <div id="aboutMePageContainer" class="page-section active">
-    <h1>About Me</h1>
-    <p>Hello! I'm Mihai-Cristian Condrea, an Android developer passionate about building delightful mobile experiences.</p>
+  <h1>About Me</h1>
+  <div class="about-summary">
+    <p>
+      Based in Bucharest, Romania, I'm a part-time Android developer at Digi România who loves pairing Kotlin and
+      Jetpack Compose work with UI/UX design and animation. Recent releases like Smart Cleaner for Android keep me
+      focused on solving everyday problems with thoughtful mobile experiences.
+    </p>
+  </div>
+
+  <section class="about-section">
+    <h2 class="section-title">Professional Experience</h2>
+    <p>
+      Working with Digi România as an early-career developer keeps me close to shipping Kotlin and Jetpack Compose features
+      while I continue to grow through real-world releases.
+    </p>
+    <ul>
+      <li><strong>Part-time Android Developer, Digi România:</strong> Build Kotlin and Jetpack Compose experiences for
+        customer-facing Android products.</li>
+      <li><strong>Early-career, Bucharest-based developer:</strong> Grow alongside Digi România's team while contributing from
+        Bucharest, Romania.</li>
+    </ul>
+  </section>
+
+  <section class="about-section">
+    <h2 class="section-title">Flagship Android Projects</h2>
+    <ul>
+      <li><strong>AppToolkit for Android:</strong> A living showcase of reusable Compose components, Material You theming,
+        and motion patterns that powers my broader app portfolio.</li>
+      <li><strong>Android Studio Tutorials:</strong> Twin learning apps that teach beginners Android development offline,
+        complete with ready-to-use layouts, sample code, and an AI companion.</li>
+      <li><strong>Smart Cleaner for Android:</strong> A free utility that offers one-tap storage cleanup and performance
+        management for Android 8.0+ devices.</li>
+      <li><strong>Weddix & Utility Collection:</strong> Event planning, shopping, dimming, sleep timers, barcode scanning,
+        and network tools designed to simplify planning and everyday routines.</li>
+    </ul>
+  </section>
+
+  <section class="about-section">
+    <h2 class="section-title">Community & Learning</h2>
+    <p>
+      I keep my apps open-source so anyone can learn from or remix the code, and I’m always up for collaborations around
+      Jetpack Compose or design systems. Continuous learning fuels that mindset—earning badges such as the Modern Android
+      App Architecture pathway, Google Cloud Innovator, and the “Completed 10+ Codelabs” milestone keeps my practice sharp.
+    </p>
+  </section>
+
+  <section class="about-section">
+    <h2 class="section-title">Personal Interests</h2>
+    <p>
+      UI/UX design, animations, and Kotlin-first development shape every project. I look for opportunities to craft Compose
+      interfaces that feel cohesive from motion to layout.
+    </p>
+  </section>
+
+  <div class="profile-card-actions">
+    <a href="#contact">
+      <md-filled-button>
+        <md-icon slot="icon"><span class="material-symbols-outlined">mail</span></md-icon>
+        Get in Touch
+      </md-filled-button>
+    </a>
+    <a href="#resume">
+      <md-filled-button>
+        <md-icon slot="icon"><span class="material-symbols-outlined">description</span></md-icon>
+        View Resume
+      </md-filled-button>
+    </a>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- restructure the About page into dedicated sections for summary, experience, flagship Android work, community learning, and interests
- add call-to-action buttons that link to the contact form and resume builder
- add page-specific styling so the refreshed content aligns with other drawer layouts on desktop and mobile

## Testing
- python3 -m http.server 8080 (manual SPA verification)


------
https://chatgpt.com/codex/tasks/task_e_68ca6c64d754832db19c741eb23320f2