### PR TITLE
Center navigation drawer footer controls

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -421,6 +421,7 @@ body.drawer-is-open {
   padding: 16px 28px 20px;
   border-top: 1px solid var(--app-border-color);
   flex-shrink: 0;
+  text-align: center;
 }
 
 .drawer-footer .theme-toggle-title {
@@ -432,7 +433,8 @@ body.drawer-is-open {
 
 .theme-button-container {
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
+  align-items: center;
   gap: 12px;
 }
 
@@ -450,12 +452,13 @@ body.drawer-is-open {
 
 .drawer-footer .drawer-legal-links {
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
   flex-wrap: wrap;
   gap: 4px;
   font-size: 0.75rem;
   margin-top: 12px;
+  width: 100%;
 }
 
 .drawer-footer .drawer-legal-links a {


### PR DESCRIPTION
## Summary
- center the navigation drawer footer actions and legal links for a balanced layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc7ff030fc832d90caaa0d42ad9293