### PR TITLE
Align theme title in navigation drawer

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -452,6 +452,7 @@ body.drawer-is-open {
   font-weight: 500;
   color: var(--app-secondary-text-color);
   margin-bottom: 8px;
+  text-align: left;
 }
 
 .theme-button-container {


### PR DESCRIPTION
## Summary
- ensure the navigation drawer's theme label is left aligned while leaving the rest of the footer content centered

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cc828cabe0832d9b35881de03ef6d1