### PR TITLE
Adjust navigation layout for desktop

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -9,6 +9,7 @@ md-top-app-bar {
   transition: background-color 200ms ease, box-shadow 200ms ease;
   display: flex;
   align-items: center;
+  width: 100%;
   padding-left: 4px;
   padding-right: 4px;
   backdrop-filter: none !important;
@@ -17,6 +18,8 @@ md-top-app-bar {
 md-top-app-bar.scrolled {
   background-color: var(--md-sys-color-surface-container, #f5f5f5);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border-bottom-left-radius: 24px;
+  border-bottom-right-radius: 24px;
 }
 
 md-top-app-bar [slot="headline"] {
@@ -357,7 +360,7 @@ md-elevated-card.contribute-card {
   --md-navigation-drawer-container-width: var(--app-drawer-inline-size);
   --md-navigation-drawer-container-height: 100%;
   --md-navigation-drawer-container-color: var(--app-drawer-bg-color);
-  --md-navigation-drawer-container-shape: 0 16px 16px 0;
+  --md-navigation-drawer-container-shape: 16px;
   --md-navigation-drawer-modal-container-elevation: 1;
   --md-navigation-drawer-standard-container-elevation: 0;
   --md-navigation-drawer-active-indicator-color: var(--md-sys-color-secondary-container);

--- a/assets/js/navigationDrawer.js
+++ b/assets/js/navigationDrawer.js
@@ -154,25 +154,19 @@ function setupResponsiveDrawerLayout() {
 function updateDrawerLayout(shouldUseStandardLayout) {
     if (!navDrawer) return;
 
-    const shouldUseStandard = Boolean(shouldUseStandardLayout);
-    document.body.dataset.drawerMode = shouldUseStandard ? 'standard' : 'modal';
+    const shouldUseStandard = false; // Always use modal drawer layout to mirror mobile behavior
+    document.body.dataset.drawerMode = 'modal';
+    document.body.classList.toggle('drawer-standard-mode', shouldUseStandard);
 
-    if (isStandardDrawerLayout === shouldUseStandard) {
-        syncDrawerState(Boolean(navDrawer.opened));
-        return;
-    }
+    if (menuButton) menuButton.toggleAttribute('hidden', shouldUseStandard);
+    if (closeDrawerButton) closeDrawerButton.toggleAttribute('hidden', shouldUseStandard);
 
     isStandardDrawerLayout = shouldUseStandard;
-    document.body.classList.toggle('drawer-standard-mode', isStandardDrawerLayout);
 
     if (isStandardDrawerLayout) {
         navDrawer.opened = true;
-        if (menuButton) menuButton.toggleAttribute('hidden', true);
-        if (closeDrawerButton) closeDrawerButton.toggleAttribute('hidden', true);
     } else {
         navDrawer.opened = false;
-        if (menuButton) menuButton.toggleAttribute('hidden', false);
-        if (closeDrawerButton) closeDrawerButton.toggleAttribute('hidden', false);
     }
 
     syncDrawerState(Boolean(navDrawer.opened));


### PR DESCRIPTION
## Summary
- make the top app bar span the full viewport width so desktop matches the mobile layout
- keep the navigation drawer in modal mode on large screens and update its styling to have rounded corners when it covers the content
- round the top app bar when it gains a surface background for a softer transition while scrolling

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd0c7bf964832d9a9ab005c4055966