### PR TITLE
Reorder GitHub ranking above podcast

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,11 +178,6 @@
                 </a>
             </div>
 
-            <div class="podcast-embed">
-                <h2 class="page-section-title">By Design Podcast</h2>
-                <iframe style="border-radius:12px" src="https://open.spotify.com/embed/show/1kfFn7caL2U2wlhaD9IMIa?utm_source=generator" width="100%" height="152" frameBorder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
-            </div>
-
             <md-filled-card class="achievement-card">
                 <div class="achievement-body">
                     <div class="achievement-icon" aria-hidden="true">
@@ -206,6 +201,11 @@
                     </a>
                 </div>
             </md-filled-card>
+
+            <div class="podcast-embed">
+                <h2 class="page-section-title">By Design Podcast</h2>
+                <iframe style="border-radius:12px" src="https://open.spotify.com/embed/show/1kfFn7caL2U2wlhaD9IMIa?utm_source=generator" width="100%" height="152" frameBorder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+            </div>
 
             <h2 class="page-section-title">Latest news</h2>
             <div class="news-section">


### PR DESCRIPTION
## Summary
- move the GitHub Committers Ranking achievement card before the By Design Podcast section so the ranking appears first

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd133a2db8832dae5797e567e7f134