### PR TITLE
Fix navigation drawer ripple shape

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -619,6 +619,8 @@ md-list-item {
   --md-list-item-container-shape: 28px;
   --md-list-item-state-layer-shape: 28px;
   --md-focus-ring-shape: 28px;
+  border-radius: var(--md-list-item-container-shape);
+  overflow: hidden;
   transition: color 0.2s ease, background-color 0.2s ease;
 }
 


### PR DESCRIPTION
## Summary
- ensure navigation drawer list items inherit a rounded container shape so state layers stay clipped

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd170cb0f8832d8e37ff48c4a646df