### PR TITLE
Implement safe area styling for edge-to-edge viewports

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -8,6 +8,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 button,
@@ -26,7 +27,11 @@ optgroup {
   width: 100%;
   margin: 0 auto;
   padding: 1rem;
-  padding-top: 70px;
+  padding-top: calc(70px + var(--safe-area-inset-top));
+  padding-bottom: calc(1rem + var(--safe-area-max-inset-bottom));
+  padding-bottom: calc(1rem + max(var(--safe-area-inset-bottom), var(--safe-area-max-inset-bottom)));
+  padding-inline-start: calc(1rem + var(--safe-area-inset-left));
+  padding-inline-end: calc(1rem + var(--safe-area-inset-right));
   flex-grow: 1;
 }
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3,15 +3,17 @@ md-top-app-bar {
   position: sticky;
   top: 0;
   z-index: 1000;
-  height: 56px;
+  min-height: 56px;
+  height: calc(56px + var(--safe-area-inset-top));
   border-radius: 0;
   box-shadow: none;
   transition: background-color 200ms ease, box-shadow 200ms ease;
   display: flex;
   align-items: center;
   width: 100%;
-  padding-left: 4px;
-  padding-right: 4px;
+  padding-top: var(--safe-area-inset-top);
+  padding-inline-start: calc(4px + var(--safe-area-inset-left));
+  padding-inline-end: calc(4px + var(--safe-area-inset-right));
   backdrop-filter: none !important;
 }
 
@@ -443,6 +445,7 @@ md-elevated-card.contribute-card {
   top: 0;
   left: 0;
   height: 100vh;
+  height: 100dvh;
   z-index: 1002;
   display: flex;
   flex-direction: column;
@@ -455,14 +458,15 @@ md-elevated-card.contribute-card {
   --md-navigation-drawer-active-indicator-color: var(--md-sys-color-secondary-container);
   --md-navigation-drawer-active-indicator-shape: 28px;
   --md-navigation-drawer-divider-color: var(--app-border-color);
+  padding-bottom: var(--safe-area-max-inset-bottom);
+  padding-bottom: max(var(--safe-area-inset-bottom), var(--safe-area-max-inset-bottom));
 }
 
 .drawer-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
+  min-height: 100vh;
+  min-height: 100dvh;
   background-color: var(--app-overlay-bg-color);
   background-color: color-mix(in srgb, var(--md-sys-color-scrim) 32%, transparent);
   z-index: 1001;
@@ -514,6 +518,9 @@ body.drawer-is-open {
   align-items: center;
   gap: 12px;
   padding: 24px 28px 16px;
+  padding-top: calc(24px + var(--safe-area-inset-top));
+  padding-inline-start: calc(28px + var(--safe-area-inset-left));
+  padding-inline-end: calc(28px + var(--safe-area-inset-right));
   border-bottom: 1px solid var(--app-border-color);
   flex-shrink: 0;
 }
@@ -528,12 +535,18 @@ body.drawer-is-open {
 .drawer-content {
   flex-grow: 1;
   padding: 8px 0 16px;
+  padding-bottom: calc(16px + var(--safe-area-max-inset-bottom));
+  padding-bottom: calc(16px + max(var(--safe-area-inset-bottom), var(--safe-area-max-inset-bottom)));
   overflow-y: auto;
   scrollbar-gutter: stable;
 }
 
 .drawer-footer {
   padding: 16px 28px 20px;
+  padding-bottom: calc(20px + var(--safe-area-max-inset-bottom));
+  padding-bottom: calc(20px + max(var(--safe-area-inset-bottom), var(--safe-area-max-inset-bottom)));
+  padding-inline-start: calc(28px + var(--safe-area-inset-left));
+  padding-inline-end: calc(28px + var(--safe-area-inset-right));
   border-top: 1px solid var(--app-border-color);
   flex-shrink: 0;
   text-align: center;
@@ -1034,13 +1047,13 @@ md-dialog { --md-dialog-container-color: var(--app-dialog-bg-color); }
 /* --- Page Loading Overlay --- */
 .page-loading-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
+  min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: var(--safe-area-inset-top) var(--safe-area-inset-right) var(--safe-area-inset-bottom) var(--safe-area-inset-left);
   background-color: var(--app-bg-color);
   z-index: 1100;
   opacity: 0;

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -55,6 +55,11 @@
   --app-footer-text-color: #5f6368;
   --app-link-color: #4285F4;
   --app-dialog-bg-color: var(--md-sys-color-surface-container-low);
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
+  --safe-area-max-inset-bottom: env(safe-area-max-inset-bottom, 0px);
  --md-sys-typescale-label-large-font-family-name: 'Poppins';
   --md-sys-typescale-label-large-font: 'Poppins';
   --md-sys-typescale-label-large-weight: 500;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Mihai's Profile</title>
     <meta name="description" content="Personal profile site of Mihai-Cristian Condrea featuring projects, music, and more.">
     <meta property="og:title" content="Mihai's Profile">


### PR DESCRIPTION
## Summary
- add viewport-fit=cover to the viewport meta tag so Chrome can render the site edge-to-edge
- expose safe-area environment variables and apply them to the app bar, content wrapper, drawer, and overlays
- switch fixed elements to dynamic viewport heights so backgrounds cover the full screen when system UI collapses

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cd6128b948832d9d8509fa9cc8281f