### PR TITLE
Improve edge-to-edge safe area handling

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -29,7 +29,6 @@ optgroup {
   padding: 1rem;
   padding-top: calc(70px + var(--safe-area-inset-top));
   padding-bottom: calc(1rem + var(--safe-area-max-inset-bottom));
-  padding-bottom: calc(1rem + max(var(--safe-area-inset-bottom), var(--safe-area-max-inset-bottom)));
   padding-inline-start: calc(1rem + var(--safe-area-inset-left));
   padding-inline-end: calc(1rem + var(--safe-area-inset-right));
   flex-grow: 1;

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -444,8 +444,7 @@ md-elevated-card.contribute-card {
   position: fixed;
   top: 0;
   left: 0;
-  height: 100vh;
-  height: 100dvh;
+  bottom: var(--safe-area-bottom-offset, 0px);
   z-index: 1002;
   display: flex;
   flex-direction: column;
@@ -459,7 +458,6 @@ md-elevated-card.contribute-card {
   --md-navigation-drawer-active-indicator-shape: 28px;
   --md-navigation-drawer-divider-color: var(--app-border-color);
   padding-bottom: var(--safe-area-max-inset-bottom);
-  padding-bottom: max(var(--safe-area-inset-bottom), var(--safe-area-max-inset-bottom));
 }
 
 .drawer-overlay {
@@ -536,7 +534,6 @@ body.drawer-is-open {
   flex-grow: 1;
   padding: 8px 0 16px;
   padding-bottom: calc(16px + var(--safe-area-max-inset-bottom));
-  padding-bottom: calc(16px + max(var(--safe-area-inset-bottom), var(--safe-area-max-inset-bottom)));
   overflow-y: auto;
   scrollbar-gutter: stable;
 }
@@ -544,7 +541,6 @@ body.drawer-is-open {
 .drawer-footer {
   padding: 16px 28px 20px;
   padding-bottom: calc(20px + var(--safe-area-max-inset-bottom));
-  padding-bottom: calc(20px + max(var(--safe-area-inset-bottom), var(--safe-area-max-inset-bottom)));
   padding-inline-start: calc(28px + var(--safe-area-inset-left));
   padding-inline-end: calc(28px + var(--safe-area-inset-right));
   border-top: 1px solid var(--app-border-color);

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -59,7 +59,8 @@
   --safe-area-inset-right: env(safe-area-inset-right, 0px);
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-inset-left: env(safe-area-inset-left, 0px);
-  --safe-area-max-inset-bottom: env(safe-area-max-inset-bottom, 0px);
+  --safe-area-max-inset-bottom: max(env(safe-area-max-inset-bottom, 0px), var(--safe-area-inset-bottom));
+  --safe-area-bottom-offset: calc(var(--safe-area-inset-bottom) - var(--safe-area-max-inset-bottom));
  --md-sys-typescale-label-large-font-family-name: 'Poppins';
   --md-sys-typescale-label-large-font: 'Poppins';
   --md-sys-typescale-label-large-weight: 500;


### PR DESCRIPTION
## Summary
- derive reusable safe area variables so the layout can account for the maximum bottom inset without forcing extra padding
- update the navigation drawer and its content/footer spacing to keep filling the gesture area while avoiding layout thrash when Chrome hides the chin
- adjust the page content padding to match the safe area strategy for edge-to-edge viewports

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd6b3e3bf8832db11e18dc695a2bc6