### PR TITLE
Add edge-to-edge prep resources and safe area tuning

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -444,7 +444,7 @@ md-elevated-card.contribute-card {
   position: fixed;
   top: 0;
   left: 0;
-  bottom: var(--safe-area-bottom-offset, 0px);
+  bottom: calc(env(safe-area-inset-bottom, 0px) - var(--safe-area-max-inset-bottom));
   z-index: 1002;
   display: flex;
   flex-direction: column;
@@ -458,6 +458,38 @@ md-elevated-card.contribute-card {
   --md-navigation-drawer-active-indicator-shape: 28px;
   --md-navigation-drawer-divider-color: var(--app-border-color);
   padding-bottom: var(--safe-area-max-inset-bottom);
+}
+
+/* --- Edge-to-Edge Prep Page --- */
+.resource-card {
+  --md-elevated-card-container-shape: 16px;
+  --md-elevated-card-container-color: var(--app-card-bg-color);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-block: 1rem;
+  padding: 1.5rem;
+  color: var(--app-text-color);
+}
+
+.resource-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.resource-card p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.resource-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.resource-actions a {
+  text-decoration: none;
 }
 
 .drawer-overlay {

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -59,8 +59,8 @@
   --safe-area-inset-right: env(safe-area-inset-right, 0px);
   --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
   --safe-area-inset-left: env(safe-area-inset-left, 0px);
-  --safe-area-max-inset-bottom: max(env(safe-area-max-inset-bottom, 0px), var(--safe-area-inset-bottom));
-  --safe-area-bottom-offset: calc(var(--safe-area-inset-bottom) - var(--safe-area-max-inset-bottom));
+  --safe-area-max-inset-bottom: max(env(safe-area-max-inset-bottom, 36px), var(--safe-area-inset-bottom));
+  --safe-area-bottom-offset: calc(env(safe-area-inset-bottom, 0px) - var(--safe-area-max-inset-bottom));
  --md-sys-typescale-label-large-font-family-name: 'Poppins';
   --md-sys-typescale-label-large-font: 'Poppins';
   --md-sys-typescale-label-large-weight: 500;

--- a/assets/js/router/routes.js
+++ b/assets/js/router/routes.js
@@ -111,6 +111,11 @@
             path: 'pages/drawer/more/apps/terms-of-service-apps.html',
             title: 'Terms of Service – End-User Software'
         },
+        {
+            id: 'edge-to-edge-prep',
+            path: 'pages/drawer/more/apps/edge-to-edge-prep.html',
+            title: 'Edge-to-Edge Prep'
+        },
         { id: 'resume', path: 'pages/resume/resume.html', title: "Mihai's Resume", onLoad: runResumeOnLoad }
     ];
 

--- a/index.html
+++ b/index.html
@@ -95,6 +95,9 @@
                         <md-list-item href="#terms-of-service-end-user-software">
                             <div slot="headline">Terms of Service</div>
                         </md-list-item>
+                        <md-list-item href="#edge-to-edge-prep" id="navEdgeToEdgePrepLink">
+                            <div slot="headline">Edge-to-Edge Prep</div>
+                        </md-list-item>
                         <md-list-item href="#legal-notices" id="navLegalNoticesLink">
                             <div slot="headline">Legal Notices</div>
                         </md-list-item>

--- a/pages/drawer/more/apps/edge-to-edge-prep.html
+++ b/pages/drawer/more/apps/edge-to-edge-prep.html
@@ -1,0 +1,134 @@
+<div id="edgeToEdgePrepPage" class="page-section active">
+    <h1>Prepare for Chrome on Android going edge-to-edge</h1>
+    <p>
+        Chrome 135 introduces dynamic edge-to-edge browsing on small-screen Android devices. The viewport can now extend
+        underneath Android's gesture navigation bar, while Chrome adds a transient "chin" that slides away as users scroll.
+        This page summarizes what the change means for this website and links to the latest guidance so every surface stays
+        polished when Chrome starts drawing behind the system bars.
+    </p>
+
+    <md-divider></md-divider>
+
+    <h2 id="site-readiness">Site readiness checklist</h2>
+    <p>
+        The site already ships <code>viewport-fit=cover</code> so content can expand into the full viewport. To align with
+        the new Chrome defaults we have tightened up our safe-area handling and recommend the following checks whenever you
+        add new components:
+    </p>
+    <ul>
+        <li>
+            Size any bottom-anchored UI (drawers, banners, FAB rails) using the
+            <code>calc(env(safe-area-inset-bottom, 0px) - var(--safe-area-max-inset-bottom))</code> pattern. This allows
+            Chrome's performance fast-path to kick in when the chin moves and keeps animations stutter-free.
+        </li>
+        <li>
+            Allow content backgrounds to bleed into the navigation area by padding elements with
+            <code>var(--safe-area-max-inset-bottom)</code>. Avoid recomputing layout by <em>not</em> applying the dynamic
+            <code>env(safe-area-inset-bottom)</code> directly as padding.
+        </li>
+        <li>
+            When embedding media or dialogs that sit flush with the edges, remember to apply the existing CSS custom
+            properties (<code>--safe-area-inset-*</code>) so nothing is obscured as Chrome animates its bars.
+        </li>
+    </ul>
+
+    <md-divider></md-divider>
+
+    <h2 id="testing">Test edge-to-edge before it launches</h2>
+    <p>
+        You can validate layouts early by enabling the relevant feature flags in Chrome Canary or Dev on Android. Toggle the
+        following entries under <code>chrome://flags</code>, then restart Chrome twice to ensure they stick:
+    </p>
+    <ul>
+        <li><strong>EdgeToEdgeBottomChin</strong> ("Enabled Debug" helps visualize the chin)</li>
+        <li><strong>DrawCutOutEdgeToEdge</strong></li>
+        <li><strong>BottomBrowserControlsRefactor</strong> &rarr; <em>Enabled Dispatch yOffset</em></li>
+        <li><strong>DynamicSafeAreaInsets</strong> and <strong>DynamicSafeAreaInsetsOnScroll</strong></li>
+        <li><strong>EdgeToEdgeWebOptIn</strong>, <strong>DrawKeyNativeEdgeToEdge</strong></li>
+        <li><strong>EdgeToEdgeSafeAreaConstraint</strong> &rarr; <em>Enabled Scrollable Variation</em></li>
+        <li>Leave <strong>DrawNativeEdgeToEdge</strong> and <strong>EdgeToEdgeEverywhere</strong> disabled</li>
+    </ul>
+    <p>
+        With these flags active, scroll through every page, especially those that pin controls to the bottom edge, and confirm
+        that content remains tappable as the chin hides and reveals itself.
+    </p>
+
+    <md-divider></md-divider>
+
+    <h2 id="resources">Latest guidance from Google</h2>
+    <md-elevated-card class="resource-card">
+        <h3>Chrome on Android edge-to-edge migration guide</h3>
+        <p>
+            Bramus walks through the visual differences between Chrome 134 and 135, explains how the safe area inset values
+            evolve as the chin animates, and provides CSS recipes for both bottom-aligned components and full-bleed layouts.
+        </p>
+        <div class="resource-actions">
+            <a href="https://developer.chrome.com/docs/css-ui/edge-to-edge/" target="_blank" rel="noopener noreferrer">
+                <md-filled-button>
+                    Read documentation
+                    <md-icon slot="icon-trailing"><span class="material-symbols-outlined">open_in_new</span></md-icon>
+                </md-filled-button>
+            </a>
+        </div>
+    </md-elevated-card>
+
+    <md-elevated-card class="resource-card">
+        <h3>Prepare for Chrome on Android going edge-to-edge</h3>
+        <p>
+            The Chrome Developers blog post highlights the user-facing changes, introduces the chin, and links directly to the
+            migration guide so teams can update their stylesheets before Chrome 135 ships broadly.
+        </p>
+        <div class="resource-actions">
+            <a href="https://developer.chrome.com/blog/chrome-android-edge-to-edge/" target="_blank"
+                rel="noopener noreferrer">
+                <md-filled-button>
+                    Visit blog post
+                    <md-icon slot="icon-trailing"><span class="material-symbols-outlined">open_in_new</span></md-icon>
+                </md-filled-button>
+            </a>
+        </div>
+    </md-elevated-card>
+
+    <md-elevated-card class="resource-card">
+        <h3>Documentation fix in Android Developer docs</h3>
+        <p>
+            A recently filed bug corrected the "GradientProtection" link inside the Android edge-to-edge guide so it now points
+            to the appropriate Jetpack API reference. Keep an eye on those docs for native-side inset handling examples.
+        </p>
+        <div class="resource-actions">
+            <a href="https://issuetracker.google.com/issues/376727177" target="_blank" rel="noopener noreferrer">
+                <md-filled-button>
+                    View bug thread
+                    <md-icon slot="icon-trailing"><span class="material-symbols-outlined">open_in_new</span></md-icon>
+                </md-filled-button>
+            </a>
+        </div>
+    </md-elevated-card>
+
+    <md-elevated-card class="resource-card">
+        <h3>Make WebViews edge-to-edge</h3>
+        <p>
+            Ash Nohe's article on the Android Developers publication shows how to bridge safe area information into owned web
+            content and how to pad third-party pages when the hosting app controls the chrome. It is invaluable when testing
+            this site inside native shells.
+        </p>
+        <div class="resource-actions">
+            <a href="https://medium.com/androiddevelopers/make-webviews-edge-to-edge" target="_blank"
+                rel="noopener noreferrer">
+                <md-filled-button>
+                    Read on Medium
+                    <md-icon slot="icon-trailing"><span class="material-symbols-outlined">open_in_new</span></md-icon>
+                </md-filled-button>
+            </a>
+        </div>
+    </md-elevated-card>
+
+    <md-divider></md-divider>
+
+    <h2 id="next-steps">Next steps</h2>
+    <p>
+        Continue to audit new UI against the safe area guidelines above, and verify in both light and dark themes. If you spot
+        any quirks while Chrome rolls out its edge-to-edge experiment, file a report with detailed reproduction steps so we can
+        react quickly. This page will be kept up to date as Google publishes additional guidance or tooling.
+    </p>
+</div>


### PR DESCRIPTION
## Summary
- add an Edge-to-Edge Prep navigation entry and page that aggregates Chrome and Android guidance for the upcoming Chrome 135 change
- update safe-area variables and navigation drawer positioning to match Chrome's recommended calc(env()) pattern and add resource card styles for the new content

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cd70cececc832d81b371178e59054d