### PR TITLE
chore: align jest jsdom environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "jest": "^30.1.3",
-        "jest-environment-jsdom": "^30.1.2",
+        "jest-environment-jsdom": "30.1.2",
         "tailwindcss": "^3.4.17"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "commonjs",
   "devDependencies": {
     "jest": "^30.1.3",
-    "jest-environment-jsdom": "^30.1.2",
+    "jest-environment-jsdom": "30.1.2",
     "tailwindcss": "^3.4.17"
   },
   "jest": {


### PR DESCRIPTION
## Summary
- pin `jest-environment-jsdom` to the published 30.1.2 release so it matches the Jest 30 line
- refresh the lockfile by reinstalling dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd81c63abc832d9b3f54d19168e40a