### PR TITLE
Add Chrome 140 compatibility improvements

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -595,6 +595,31 @@ body.drawer-is-open {
   gap: 12px;
 }
 
+.theme-help-button {
+  width: 40px;
+  height: 40px;
+  border: none;
+  padding: 0;
+  border-radius: 50%;
+  background-color: transparent;
+  color: var(--app-text-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.theme-help-button:focus-visible,
+.theme-help-button:hover {
+  background-color: var(--app-theme-button-selected-bg);
+  color: var(--md-sys-color-primary);
+}
+
+.theme-help-button .material-symbols-outlined {
+  font-size: 20px;
+}
+
 .theme-button-container md-icon-button {
   --md-icon-button-icon-color: var(--app-text-color);
   border-radius: 50%; /* Ensure it's round */
@@ -605,6 +630,112 @@ body.drawer-is-open {
 .theme-button-container md-icon-button.selected {
   background-color: var(--app-theme-button-selected-bg);
   --md-icon-button-icon-color: var(--md-sys-color-primary);
+}
+
+.theme-help-popover {
+  border: 1px solid var(--app-border-color);
+  background-color: var(--app-card-bg-color);
+  color: var(--app-text-color);
+  border-radius: 18px;
+  padding: 16px;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.22);
+  max-width: min(320px, calc(100vw - 48px));
+  font-size: 0.9rem;
+}
+
+.theme-help-popover::backdrop {
+  background-color: rgba(0, 0, 0, 0.25);
+}
+
+.theme-help-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.theme-help-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.theme-help-close {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 16px;
+  background-color: transparent;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.theme-help-close:focus-visible,
+.theme-help-close:hover {
+  background-color: var(--app-theme-button-selected-bg);
+  color: var(--md-sys-color-primary);
+}
+
+.theme-help-close .material-symbols-outlined {
+  font-size: 18px;
+}
+
+.theme-help-invoker {
+  margin: 0 0 12px 0;
+  font-size: 0.75rem;
+  color: var(--app-secondary-text-color);
+}
+
+.theme-help-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: theme-help-counter;
+  display: grid;
+  gap: 12px;
+}
+
+.theme-help-list li {
+  counter-increment: theme-help-counter;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: flex-start;
+  position: relative;
+  font-size: 0.85rem;
+}
+
+.theme-help-list li::before {
+  content: counter(theme-help-counter);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background-color: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+  font-weight: 600;
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.theme-help-list li::after {
+  content: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==") /
+    "Theme option " counter(theme-help-counter) " – " attr(data-theme-option);
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
 }
 
 .drawer-footer .drawer-legal-links {

--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -1,0 +1,12 @@
+@font-face {
+  font-family: 'Material Symbols Outlined';
+  font-style: normal;
+  font-weight: 100 700;
+  src: url('https://fonts.gstatic.com/s/materialsymbolsoutlined/v280/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOem.ttf') format('truetype');
+  font-display: swap;
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 400,
+    'GRAD' 0,
+    'opsz' 24;
+}

--- a/assets/js/toggleSupport.js
+++ b/assets/js/toggleSupport.js
@@ -1,0 +1,66 @@
+const popoverInvokerMap = new WeakMap();
+
+document.addEventListener('DOMContentLoaded', () => {
+    const themePopover = document.getElementById('themeHelpPopover');
+    const helpButton = document.getElementById('themeHelpButton');
+    const invokerDescription = document.getElementById('themeHelpInvoker');
+
+    if (!themePopover || typeof themePopover.showPopover !== 'function') {
+        if (helpButton) {
+            helpButton.hidden = true;
+        }
+        return;
+    }
+
+    const clearInvokerMessage = () => {
+        if (invokerDescription) {
+            invokerDescription.hidden = true;
+            invokerDescription.textContent = '';
+        }
+    };
+
+    themePopover.addEventListener('toggle', (event) => {
+        const popover = event.target;
+        if (!popover) return;
+
+        const nextState = typeof event.newState === 'string'
+            ? event.newState
+            : (popover.matches(':popover-open') ? 'open' : 'closed');
+
+        if (nextState === 'open') {
+            let sourceElement = null;
+            if ('source' in event && event.source instanceof HTMLElement) {
+                sourceElement = event.source;
+            } else if (document.activeElement instanceof HTMLElement) {
+                sourceElement = document.activeElement;
+            }
+
+            if (sourceElement) {
+                popoverInvokerMap.set(popover, sourceElement);
+                if (invokerDescription) {
+                    const labelText = sourceElement.getAttribute('aria-label')
+                        || sourceElement.textContent?.trim()
+                        || sourceElement.dataset?.theme
+                        || '';
+                    if (labelText) {
+                        invokerDescription.textContent = `Opened from the ${labelText} control.`;
+                        invokerDescription.hidden = false;
+                    } else {
+                        clearInvokerMessage();
+                    }
+                }
+            } else {
+                clearInvokerMessage();
+            }
+        } else {
+            const storedInvoker = popoverInvokerMap.get(popover);
+            popoverInvokerMap.delete(popover);
+            clearInvokerMessage();
+
+            if (storedInvoker && document.contains(storedInvoker) && typeof storedInvoker.focus === 'function') {
+                storedInvoker.focus();
+            }
+        }
+    });
+});
+

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
         integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/fonts.css">
     <link rel="stylesheet" href="assets/css/variables.css">
     <link rel="stylesheet" href="assets/css/base.css">
     <link rel="stylesheet" href="assets/css/components.css">
@@ -118,6 +118,27 @@
                 <md-icon-button id="autoThemeButton" aria-label="Auto theme" data-theme="auto">
                     <md-icon><span class="material-symbols-outlined">brightness_auto</span></md-icon>
                 </md-icon-button>
+                <button type="button" id="themeHelpButton" class="theme-help-button"
+                    popovertarget="themeHelpPopover" popovertargetaction="toggle"
+                    aria-label="Learn about theme behavior">
+                    <span class="material-symbols-outlined" aria-hidden="true">help</span>
+                </button>
+            </div>
+            <div id="themeHelpPopover" popover class="theme-help-popover" role="dialog"
+                aria-labelledby="themeHelpTitle">
+                <div class="theme-help-header">
+                    <h3 id="themeHelpTitle">Theme options</h3>
+                    <button type="button" class="theme-help-close" popovertarget="themeHelpPopover"
+                        popovertargetaction="hide" aria-label="Close theme help">
+                        <span class="material-symbols-outlined" aria-hidden="true">close</span>
+                    </button>
+                </div>
+                <p id="themeHelpInvoker" class="theme-help-invoker" hidden></p>
+                <ol class="theme-help-list">
+                    <li data-theme-option="Light theme"><strong>Light</strong> &mdash; Always use the bright palette.</li>
+                    <li data-theme-option="Dark theme"><strong>Dark</strong> &mdash; Keep surfaces dim and text high contrast.</li>
+                    <li data-theme-option="Auto theme"><strong>Auto</strong> &mdash; Follow the system color scheme.</li>
+                </ol>
             </div>
             <div class="drawer-legal-links text-gray-500 mt-2">
                 <a href="#privacy-policy">Privacy Policy</a>
@@ -283,6 +304,7 @@
     <script src="assets/js/utils.js" defer></script>
     <script src="assets/js/theme.js" defer></script>
     <script src="assets/js/navigationDrawer.js" defer></script>
+    <script src="assets/js/toggleSupport.js" defer></script>
     <script src="assets/js/bloggerApi.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.min.js" defer></script>
     <script src="assets/js/resume.js" defer></script>


### PR DESCRIPTION
## Summary
- load Material Symbols through a local @font-face block that uses the new font-variation-settings descriptor supported in Chrome 140
- add a theme drawer help popover whose content demonstrates counter() in generated alt text and explains each theme option
- hook ToggleEvent-aware focus management so the popover restores focus to the button that opened it, with graceful fallback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd84d383dc832d9a2a3fc16b08bb30