### PR TITLE
Add Jest tests for songs loader and expose module functions

### DIFF
--- a/__tests__/songs.test.js
+++ b/__tests__/songs.test.js
@@ -1,0 +1,84 @@
+const PLACEHOLDER_SRC = 'assets/images/placeholder.png';
+
+describe('songs module', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        global.fetch = jest.fn();
+        document.body.innerHTML = `
+            <div id="songsGrid"></div>
+            <div id="songs-status" style="display:none"></div>
+        `;
+    });
+
+    afterEach(() => {
+        delete global.fetch;
+    });
+
+    test('fetchChannelVideos throws an error with response message when request fails', async () => {
+        const errorText = 'Something went wrong';
+        const mockText = jest.fn().mockResolvedValue(errorText);
+        const response = {
+            ok: false,
+            status: 502,
+            text: mockText
+        };
+
+        global.fetch.mockResolvedValue(response);
+
+        const { fetchChannelVideos } = require('../assets/js/songs.js');
+
+        await expect(fetchChannelVideos('channel123')).rejects.toThrow(
+            `HTTP error! status: 502, message: ${errorText}`
+        );
+        expect(mockText).toHaveBeenCalledTimes(1);
+    });
+
+    test('loadSongs renders fetched tracks, applies fallback image, and hides status indicator', async () => {
+        const mockJson = jest.fn().mockResolvedValue({
+            relatedStreams: [
+                {
+                    title: 'First Song',
+                    uploaderName: 'First Artist',
+                    thumbnail: 'https://cdn.example.com/thumb1.jpg',
+                    url: '/watch?v=first'
+                },
+                {
+                    title: 'Second Song',
+                    uploaderName: 'Second Artist',
+                    thumbnail: null,
+                    url: '/watch?v=second'
+                }
+            ]
+        });
+
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: mockJson
+        });
+
+        const { loadSongs } = require('../assets/js/songs.js');
+        const status = document.getElementById('songs-status');
+        status.style.display = 'block';
+
+        await loadSongs();
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(mockJson).toHaveBeenCalledTimes(1);
+
+        const cards = document.querySelectorAll('#songsGrid .song-card');
+        expect(cards).toHaveLength(2);
+
+        const [firstCard, secondCard] = cards;
+        const firstImg = firstCard.querySelector('img');
+        expect(firstImg.src).toContain('https://cdn.example.com/thumb1.jpg');
+        expect(firstImg.alt).toBe('First Song');
+        expect(firstCard.querySelector('h3').textContent).toBe('First Song');
+        expect(firstCard.querySelector('p').textContent).toBe('First Artist');
+        expect(firstCard.querySelector('a').href).toBe('https://www.youtube.com/watch?v=first');
+
+        const secondImg = secondCard.querySelector('img');
+        expect(secondImg.src).toContain(PLACEHOLDER_SRC);
+
+        expect(status.style.display).toBe('none');
+    });
+});

--- a/assets/js/songs.js
+++ b/assets/js/songs.js
@@ -55,3 +55,10 @@ document.addEventListener('DOMContentLoaded', () => {
         loadSongs();
     }
 });
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        fetchChannelVideos,
+        loadSongs
+    };
+}


### PR DESCRIPTION
## Summary
- export the songs module helpers when running in Node to support unit testing
- add Jest tests that mock fetch to validate error handling and DOM rendering in loadSongs

## Testing
- npm test -- --runInBand --verbose

------
https://chatgpt.com/codex/tasks/task_e_68cd8a0921ac832d9bf5ca1b29c6fcfc