### PR TITLE
Fix Material Symbols icon rendering

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -52,7 +52,19 @@ optgroup {
 }
 
 .material-symbols-outlined {
-  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  font-family: 'Material Symbols Outlined', sans-serif;
+  font-weight: normal;
+  font-style: normal;
   font-size: 20px;
   line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  font-feature-settings: 'liga';
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
 }


### PR DESCRIPTION
## Summary
- ensure elements using the Material Symbols Outlined glyphs request the correct font family
- add supporting typography settings so icons render consistently across the UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd952f06e4832dad4b3d214236ccb0