### PR TITLE
Restore button icon padding

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -705,15 +705,40 @@ md-list-item[type="button"].expanded md-icon[slot="end"] {
 }
 
 /* --- Buttons --- */
-md-filled-button md-icon {
-  margin-inline-end: 8px;
-  display: inline-flex;
-  align-items: center;
+:root {
+  --app-button-icon-inline-padding: 16px;
+  --app-text-button-icon-inline-padding: 12px;
 }
 
 md-filled-button {
-  display: inline-flex;
-  align-items: center;
+  --md-filled-button-with-leading-icon-leading-space: var(--app-button-icon-inline-padding);
+  --md-filled-button-with-leading-icon-trailing-space: var(--app-button-icon-inline-padding);
+  --md-filled-button-with-trailing-icon-leading-space: var(--app-button-icon-inline-padding);
+  --md-filled-button-with-trailing-icon-trailing-space: var(--app-button-icon-inline-padding);
+}
+
+md-outlined-button {
+  --md-outlined-button-with-leading-icon-leading-space: var(--app-button-icon-inline-padding);
+  --md-outlined-button-with-leading-icon-trailing-space: var(--app-button-icon-inline-padding);
+  --md-outlined-button-with-trailing-icon-leading-space: var(--app-button-icon-inline-padding);
+  --md-outlined-button-with-trailing-icon-trailing-space: var(--app-button-icon-inline-padding);
+}
+
+:is(md-filled-button, md-outlined-button)[has-icon] {
+  padding-inline-start: var(--app-button-icon-inline-padding);
+  padding-inline-end: var(--app-button-icon-inline-padding);
+}
+
+md-text-button {
+  --md-text-button-with-leading-icon-leading-space: var(--app-text-button-icon-inline-padding);
+  --md-text-button-with-leading-icon-trailing-space: var(--app-text-button-icon-inline-padding);
+  --md-text-button-with-trailing-icon-leading-space: var(--app-text-button-icon-inline-padding);
+  --md-text-button-with-trailing-icon-trailing-space: var(--app-text-button-icon-inline-padding);
+}
+
+md-text-button[has-icon] {
+  padding-inline-start: var(--app-text-button-icon-inline-padding);
+  padding-inline-end: var(--app-text-button-icon-inline-padding);
 }
 
 /* --- Footer --- */

--- a/index.html
+++ b/index.html
@@ -219,9 +219,9 @@
                 </div>
                 <div class="view-all-posts-container">
                     <a href="https://d4rk7355608.blogspot.com/" target="_blank" rel="noopener noreferrer">
-                        <md-outlined-button>
+                        <md-outlined-button trailing-icon>
                             View All Posts
-                            <md-icon slot="icon-trailing"><span
+                            <md-icon slot="icon" aria-hidden="true"><span
                                     class="material-symbols-outlined">arrow_forward</span></md-icon>
                         </md-outlined-button>
                     </a>


### PR DESCRIPTION
## Summary
- reintroduce consistent inline padding for icon buttons by defining app-specific spacing tokens and applying them to Material filled, outlined, and text buttons
- update the View All Posts button to use the Material Web trailing icon API so the arrow icon inherits the restored spacing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd97f2ac2c832da59985e7c66d34a0