### PR TITLE
Refine Material Symbols font families

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -52,7 +52,7 @@ optgroup {
 }
 
 .material-symbols-outlined {
-  font-family: 'Material Symbols Outlined', sans-serif;
+  font-family: var(--material-symbols-font, 'Material Symbols Outlined'), 'Material Symbols Outlined', sans-serif;
   font-weight: normal;
   font-style: normal;
   font-size: 20px;
@@ -66,5 +66,14 @@ optgroup {
   font-feature-settings: 'liga';
   -webkit-font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
-  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
+.material-symbols-filled {
+  --material-symbols-font: 'Material Symbols Filled';
+  font-family: 'Material Symbols Filled', 'Material Symbols Outlined', sans-serif;
+}
+
+.material-symbols-semibold {
+  --material-symbols-font: 'Material Symbols SemiBold';
+  font-family: 'Material Symbols SemiBold', 'Material Symbols Outlined', sans-serif;
 }

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -30,6 +30,10 @@ md-top-app-bar [slot="headline"] {
   font-weight: 500;
 }
 
+md-top-app-bar .material-symbols-outlined {
+  font-family: 'Material Symbols SemiBold', 'Material Symbols Outlined', sans-serif;
+}
+
 md-top-app-bar md-icon,
 md-top-app-bar [slot="navigationIcon"],
 md-top-app-bar [slot="actionIcon"] {
@@ -570,9 +574,17 @@ body.drawer-is-open {
   transition: background-color 0.2s ease;
 }
 
+.theme-button-container md-icon-button .material-symbols-outlined {
+  font-family: 'Material Symbols SemiBold', 'Material Symbols Outlined', sans-serif;
+}
+
 .theme-button-container md-icon-button.selected {
   background-color: var(--app-theme-button-selected-bg);
   --md-icon-button-icon-color: var(--md-sys-color-primary);
+}
+
+.theme-button-container md-icon-button.selected .material-symbols-outlined {
+  font-family: 'Material Symbols Filled', 'Material Symbols Outlined', sans-serif;
 }
 
 .drawer-footer .drawer-legal-links {
@@ -658,15 +670,12 @@ md-list-item a[slot="headline"] {
 
 .navigation-drawer md-list-item .material-symbols-outlined {
   font-size: 24px;
-  transition: color 0.2s ease, font-variation-settings 0.2s ease;
+  transition: color 0.2s ease, font-family 0.2s ease;
+  font-family: 'Material Symbols SemiBold', 'Material Symbols Outlined', sans-serif;
 }
 
 .navigation-drawer md-list-item.nav-item-active .material-symbols-outlined {
-  font-variation-settings: 'FILL' 1, 'wght' 500, 'GRAD' 0, 'opsz' 24;
-}
-
-.navigation-drawer md-list-item:not(.nav-item-active) .material-symbols-outlined {
-  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  font-family: 'Material Symbols Filled', 'Material Symbols Outlined', sans-serif;
 }
 
 .navigation-drawer md-list-item:hover:not(.nav-item-active) {

--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -10,3 +10,29 @@
     'GRAD' 0,
     'opsz' 24;
 }
+
+@font-face {
+  font-family: 'Material Symbols Filled';
+  font-style: normal;
+  font-weight: 100 700;
+  src: url('https://fonts.gstatic.com/s/materialsymbolsoutlined/v280/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOem.ttf') format('truetype');
+  font-display: swap;
+  font-variation-settings:
+    'FILL' 1,
+    'wght' 400,
+    'GRAD' 0,
+    'opsz' 24;
+}
+
+@font-face {
+  font-family: 'Material Symbols SemiBold';
+  font-style: normal;
+  font-weight: 100 700;
+  src: url('https://fonts.gstatic.com/s/materialsymbolsoutlined/v280/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOem.ttf') format('truetype');
+  font-display: swap;
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 600,
+    'GRAD' 0,
+    'opsz' 24;
+}


### PR DESCRIPTION
## Summary
- add dedicated Material Symbols font-face descriptors for filled and semi-bold variants that share the same source file
- adjust the base Material Symbols utility classes to rely on neutral font-family defaults with helper classes for filled and semi-bold usages
- retune navigation drawer, app bar, and theme toggle icons to switch font families for active and selected states instead of altering variation settings

## Testing
- npm test
- python3 -m http.server 4173 (manual smoke test of icon rendering)


------
https://chatgpt.com/codex/tasks/task_e_68cdb1f62820832da0f3c0d2bb940761