### PR TITLE
Add spring motion styles for button interactions

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -790,6 +790,45 @@ md-divider.profile-section-divider {
   text-decoration: none;
 }
 
+.profile-card-actions a md-outlined-button,
+.profile-card-actions a md-filled-button,
+.achievement-card .achievement-actions md-text-button {
+  box-shadow: none;
+  transition: background-color 180ms var(--app-motion-spring),
+    color 180ms var(--app-motion-spring),
+    box-shadow 240ms var(--app-motion-bounce),
+    transform 240ms var(--app-motion-spring);
+}
+
+.profile-card-actions a md-outlined-button:hover,
+.profile-card-actions a md-outlined-button:focus-visible,
+.profile-card-actions a md-filled-button:hover,
+.profile-card-actions a md-filled-button:focus-visible,
+.achievement-card .achievement-actions md-text-button:hover,
+.achievement-card .achievement-actions md-text-button:focus-visible {
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.15);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .profile-card-actions a md-outlined-button,
+  .profile-card-actions a md-filled-button,
+  .achievement-card .achievement-actions md-text-button {
+    transition: background-color 180ms ease,
+      color 180ms ease,
+      box-shadow 240ms ease;
+  }
+
+  .profile-card-actions a md-outlined-button:hover,
+  .profile-card-actions a md-outlined-button:focus-visible,
+  .profile-card-actions a md-filled-button:hover,
+  .profile-card-actions a md-filled-button:focus-visible,
+  .achievement-card .achievement-actions md-text-button:hover,
+  .achievement-card .achievement-actions md-text-button:focus-visible {
+    transform: none;
+  }
+}
+
 /* Optional: To make buttons in actions take more width on smaller screens if they wrap */
 @media (max-width: 480px) {
   .profile-card-actions {

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -108,6 +108,20 @@
   --md-sys-typescale-display-small-weight: 500;
 }
 
+@supports (animation-timing-function: linear(0, 0.5, 1)) {
+  :root {
+    --app-motion-spring: linear(0, 0.35 20%, 0.72 45%, 1.08 75%, 1);
+    --app-motion-bounce: linear(0, 0.55 25%, 1.05 60%, 1);
+  }
+}
+
+@supports not (animation-timing-function: linear(0, 0.5, 1)) {
+  :root {
+    --app-motion-spring: ease;
+    --app-motion-bounce: ease;
+  }
+}
+
 html.dark {
   --md-sys-color-primary: #96dea1;
   --md-sys-color-on-primary: #003912;


### PR DESCRIPTION
## Summary
- add motion timing custom properties with a linear-easing fallback
- apply springy hover/focus transitions to profile and achievement card buttons with reduced-motion guards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc134873c832d8f9967726568f64f