### PR TITLE
Add per-route metadata management and SEO updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,51 @@ in the project root so they are included in the published bundle.
 - You can re-run `npm run verify:seo` at any time to confirm the sitemap and robots files
   are still available before pushing a release.
 
+### Metadata & Social Sharing
+
+- Every client-side route now carries a `metadata` block defined in
+  `assets/js/router/routes.js`. The router sanitizes those values and
+  a lightweight metadata manager updates `<meta>` and canonical tags each
+  time navigation occurs.
+- When registering a new route you **must** provide the following fields to
+  keep SEO and social previews accurate:
+  - `description`: A short summary tailored to the page’s search intent.
+  - `keywords`: An array (or comma-separated string) of focused keywords.
+  - `canonicalSlug`: Either the hash slug (e.g. `projects`) or a fully
+    qualified canonical URL.
+  - `openGraph`: Supply at least a `title`, `description`, and `type`
+    (`website`, `article`, `music.playlist`, etc.). The manager fills in the
+    default image unless you override it.
+  - `twitter`: Provide `title`/`description` overrides when they should differ
+    from the Open Graph copy.
+- Example route registration:
+
+  ```js
+  RouterRoutes.registerRoute({
+    id: 'case-study',
+    path: 'pages/case-study.html',
+    title: 'Case Study',
+    metadata: {
+      description: 'Deep dive into a Compose motion project.',
+      keywords: ['Jetpack Compose animation', 'Material motion case study'],
+      canonicalSlug: 'case-study',
+      openGraph: {
+        title: 'Compose Motion Case Study | Mihai-Cristian Condrea',
+        description: 'Deep dive into a Compose motion project.',
+        type: 'article'
+      },
+      twitter: {
+        title: 'Compose Motion Case Study',
+        description: 'See how Material motion patterns were built for Android.'
+      }
+    }
+  });
+  ```
+
+- The metadata manager lives in `assets/js/metadataManager.js`. It ensures
+  the description, keyword, Open Graph, Twitter, and canonical tags always
+  reflect the active route while falling back to opinionated defaults.
+
 ### YouTube Channel Feed
 
 The songs page fetches track information from the D4rK Rekords YouTube channel

--- a/__tests__/metadataManager.test.js
+++ b/__tests__/metadataManager.test.js
@@ -1,0 +1,83 @@
+const path = require('path');
+
+describe('SiteMetadata.updateForRoute', () => {
+  const modulePath = path.resolve(__dirname, '../assets/js/metadataManager.js');
+
+  beforeEach(() => {
+    jest.resetModules();
+    document.head.innerHTML = '';
+    delete global.SiteMetadata;
+    require(modulePath);
+  });
+
+  test('applies provided route metadata to document head', () => {
+    const route = {
+      id: 'projects',
+      title: 'Projects',
+      metadata: {
+        description: 'Detailed showcase of current Android and web experiments.',
+        keywords: ['android case study', 'jetpack compose ui'],
+        canonicalSlug: 'projects',
+        openGraph: {
+          title: 'Projects | Showcase',
+          description: 'Detailed showcase of current Android and web experiments.',
+          type: 'article',
+          image: 'https://example.com/og-image.png',
+          imageAlt: 'Preview of featured projects'
+        },
+        twitter: {
+          card: 'summary',
+          title: 'Projects on Display',
+          description: 'Detailed showcase of current Android and web experiments.',
+          image: 'https://example.com/twitter-image.png',
+          site: '@ExampleSite',
+          creator: '@ExampleCreator'
+        }
+      }
+    };
+
+    const result = global.SiteMetadata.updateForRoute(route, { pageTitle: 'Projects', pageId: 'projects' });
+
+    expect(result.canonicalUrl).toBe('https://mihaicristiancondrea.github.io/profile/#projects');
+    expect(document.querySelector('meta[name="description"]').getAttribute('content'))
+      .toBe('Detailed showcase of current Android and web experiments.');
+    expect(document.querySelector('meta[name="keywords"]').getAttribute('content'))
+      .toBe('android case study, jetpack compose ui');
+    expect(document.querySelector('meta[property="og:title"]').getAttribute('content'))
+      .toBe('Projects | Showcase');
+    expect(document.querySelector('meta[property="og:type"]').getAttribute('content'))
+      .toBe('article');
+    expect(document.querySelector('meta[property="og:image"]').getAttribute('content'))
+      .toBe('https://example.com/og-image.png');
+    expect(document.querySelector('meta[property="og:image:alt"]').getAttribute('content'))
+      .toBe('Preview of featured projects');
+    expect(document.querySelector('meta[name="twitter:card"]').getAttribute('content'))
+      .toBe('summary');
+    expect(document.querySelector('meta[name="twitter:title"]').getAttribute('content'))
+      .toBe('Projects on Display');
+    expect(document.querySelector('meta[name="twitter:image"]').getAttribute('content'))
+      .toBe('https://example.com/twitter-image.png');
+    expect(document.querySelector('meta[name="twitter:site"]').getAttribute('content'))
+      .toBe('@ExampleSite');
+    expect(document.querySelector('meta[name="twitter:creator"]').getAttribute('content'))
+      .toBe('@ExampleCreator');
+    expect(document.querySelector('link[rel="canonical"]').getAttribute('href'))
+      .toBe('https://mihaicristiancondrea.github.io/profile/#projects');
+  });
+
+  test('falls back to defaults when metadata is missing', () => {
+    const route = { id: 'unknown-page', title: 'Unknown Page' };
+
+    const result = global.SiteMetadata.updateForRoute(route, {});
+
+    expect(result.canonicalUrl).toBe('https://mihaicristiancondrea.github.io/profile/#unknown-page');
+    expect(document.querySelector('meta[property="og:title"]').getAttribute('content'))
+      .toBe('Unknown Page');
+    expect(document.querySelector('meta[name="description"]').getAttribute('content'))
+      .toContain('Mihai-Cristian Condrea');
+    expect(document.querySelector('meta[name="keywords"]').getAttribute('content'))
+      .toContain('Android developer');
+    expect(document.querySelector('link[rel="canonical"]').getAttribute('href'))
+      .toBe('https://mihaicristiancondrea.github.io/profile/#unknown-page');
+  });
+});

--- a/__tests__/router.test.js
+++ b/__tests__/router.test.js
@@ -429,12 +429,27 @@ describe('RouterRoutes registry', () => {
       onLoad
     });
 
-    expect(registered).toEqual({
+    expect(registered).toEqual(expect.objectContaining({
       id: 'custom-route',
       path: 'pages/custom.html',
       title: 'Custom Route',
-      onLoad
-    });
+      onLoad,
+      metadata: expect.objectContaining({
+        description: expect.any(String),
+        canonicalSlug: 'custom-route',
+        openGraph: expect.objectContaining({
+          title: 'Custom Route',
+          description: expect.any(String)
+        }),
+        twitter: expect.objectContaining({
+          title: 'Custom Route',
+          description: expect.any(String)
+        })
+      })
+    }));
+
+    expect(Array.isArray(registered.metadata.keywords)).toBe(true);
+    expect(registered.metadata.keywords.length).toBeGreaterThan(0);
 
     expect(RouterRoutes.hasRoute('#custom-route')).toBe(true);
 
@@ -445,6 +460,11 @@ describe('RouterRoutes registry', () => {
       title: 'Custom Route',
       onLoad
     });
+    expect(storedRoute.metadata).toEqual(expect.objectContaining({
+      canonicalSlug: 'custom-route'
+    }));
+    expect(Array.isArray(storedRoute.metadata.keywords)).toBe(true);
+    expect(storedRoute.metadata.openGraph.title).toBe('Custom Route');
 
     expect(registered).not.toBe(storedRoute);
     expect(RouterRoutes.normalizeRouteId('  #custom-route ')).toBe('custom-route');
@@ -452,7 +472,12 @@ describe('RouterRoutes registry', () => {
     const allRoutes = RouterRoutes.getRoutes();
     expect(allRoutes).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: 'custom-route', path: 'pages/custom.html', title: 'Custom Route' })
+        expect.objectContaining({
+          id: 'custom-route',
+          path: 'pages/custom.html',
+          title: 'Custom Route',
+          metadata: expect.any(Object)
+        })
       ])
     );
   });

--- a/assets/js/metadataManager.js
+++ b/assets/js/metadataManager.js
@@ -1,0 +1,212 @@
+(function (global) {
+    const DEFAULT_TITLE = "Mihai's Profile";
+    const DEFAULT_DESCRIPTION = "Explore Mihai-Cristian Condrea's Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.";
+    const DEFAULT_KEYWORDS = [
+        'Mihai Cristian Condrea',
+        'Android developer portfolio',
+        'Jetpack Compose',
+        'Kotlin apps',
+        'Material Design UI'
+    ];
+    const SITE_BASE_URL = 'https://mihaicristiancondrea.github.io/profile/';
+    const DEFAULT_IMAGE = 'https://mihaicristiancondrea.github.io/profile/assets/images/profile/cv_profile_pic.png';
+    const DEFAULT_IMAGE_ALT = 'Portrait of Android developer Mihai-Cristian Condrea';
+    const DEFAULT_OG_TYPE = 'website';
+    const DEFAULT_TWITTER_CARD = 'summary_large_image';
+    const DEFAULT_TWITTER_HANDLE = '@MihaiCrstian';
+
+    function isDomAvailable() {
+        return typeof document !== 'undefined' && !!document.head;
+    }
+
+    function ensureMetaByName(name) {
+        if (!isDomAvailable()) {
+            return null;
+        }
+        let element = document.head.querySelector(`meta[name="${name}"]`);
+        if (!element) {
+            element = document.createElement('meta');
+            element.setAttribute('name', name);
+            document.head.appendChild(element);
+        }
+        return element;
+    }
+
+    function ensureMetaByProperty(property) {
+        if (!isDomAvailable()) {
+            return null;
+        }
+        let element = document.head.querySelector(`meta[property="${property}"]`);
+        if (!element) {
+            element = document.createElement('meta');
+            element.setAttribute('property', property);
+            document.head.appendChild(element);
+        }
+        return element;
+    }
+
+    function ensureCanonicalLink() {
+        if (!isDomAvailable()) {
+            return null;
+        }
+        let element = document.head.querySelector('link[rel="canonical"]');
+        if (!element) {
+            element = document.createElement('link');
+            element.setAttribute('rel', 'canonical');
+            document.head.appendChild(element);
+        }
+        return element;
+    }
+
+    function updateMetaTag(element, content) {
+        if (!element) {
+            return;
+        }
+        const value = typeof content === 'string' ? content : '';
+        element.setAttribute('content', value);
+    }
+
+    function toKeywordString(keywords) {
+        if (Array.isArray(keywords) && keywords.length) {
+            return keywords.join(', ');
+        }
+        if (typeof keywords === 'string' && keywords.trim()) {
+            return keywords.trim();
+        }
+        return DEFAULT_KEYWORDS.join(', ');
+    }
+
+    function sanitizeSlug(slug) {
+        if (typeof slug !== 'string') {
+            return '';
+        }
+        const trimmed = slug.trim();
+        if (!trimmed || trimmed === '/' || trimmed === '#') {
+            return '';
+        }
+        if (/^https?:\/\//i.test(trimmed)) {
+            return trimmed;
+        }
+        return trimmed.replace(/^[/#]+/, '').replace(/[/#]+$/, '');
+    }
+
+    function buildCanonicalUrl(slug) {
+        const sanitized = sanitizeSlug(slug);
+        if (!sanitized) {
+            return SITE_BASE_URL;
+        }
+        if (/^https?:\/\//i.test(sanitized)) {
+            return sanitized;
+        }
+        return `${SITE_BASE_URL}#${sanitized}`;
+    }
+
+    function cloneMetadata(metadata) {
+        if (!metadata || typeof metadata !== 'object') {
+            return null;
+        }
+        return {
+            description: metadata.description,
+            keywords: Array.isArray(metadata.keywords) ? [...metadata.keywords] : metadata.keywords,
+            canonicalSlug: metadata.canonicalSlug,
+            openGraph: metadata.openGraph && typeof metadata.openGraph === 'object' ? { ...metadata.openGraph } : null,
+            twitter: metadata.twitter && typeof metadata.twitter === 'object' ? { ...metadata.twitter } : null
+        };
+    }
+
+    function updateForRoute(routeConfig, options = {}) {
+        if (!isDomAvailable()) {
+            return null;
+        }
+
+        const clonedMetadata = cloneMetadata(routeConfig && routeConfig.metadata);
+        const fallbackId = options.pageId || (routeConfig && routeConfig.id) || '';
+        const fallbackTitle = options.pageTitle || (routeConfig && routeConfig.title) || DEFAULT_TITLE;
+
+        const description = clonedMetadata && clonedMetadata.description
+            ? clonedMetadata.description
+            : DEFAULT_DESCRIPTION;
+
+        const keywords = toKeywordString(clonedMetadata && clonedMetadata.keywords);
+
+        const canonicalInput = clonedMetadata && Object.prototype.hasOwnProperty.call(clonedMetadata, 'canonicalSlug')
+            ? clonedMetadata.canonicalSlug
+            : (fallbackId && fallbackId !== 'home' ? fallbackId : '');
+        const canonicalUrl = buildCanonicalUrl(canonicalInput);
+
+        const openGraph = clonedMetadata && clonedMetadata.openGraph ? clonedMetadata.openGraph : {};
+        const ogTitle = typeof openGraph.title === 'string' && openGraph.title.trim()
+            ? openGraph.title
+            : fallbackTitle;
+        const ogDescription = typeof openGraph.description === 'string' && openGraph.description.trim()
+            ? openGraph.description
+            : description;
+        const ogType = typeof openGraph.type === 'string' && openGraph.type.trim()
+            ? openGraph.type
+            : DEFAULT_OG_TYPE;
+        const ogImage = typeof openGraph.image === 'string' && openGraph.image.trim()
+            ? openGraph.image
+            : DEFAULT_IMAGE;
+        const ogImageAlt = typeof openGraph.imageAlt === 'string' && openGraph.imageAlt.trim()
+            ? openGraph.imageAlt
+            : DEFAULT_IMAGE_ALT;
+        const ogSiteName = typeof openGraph.siteName === 'string' && openGraph.siteName.trim()
+            ? openGraph.siteName
+            : DEFAULT_TITLE;
+
+        const twitter = clonedMetadata && clonedMetadata.twitter ? clonedMetadata.twitter : {};
+        const twitterCard = typeof twitter.card === 'string' && twitter.card.trim()
+            ? twitter.card
+            : DEFAULT_TWITTER_CARD;
+        const twitterTitle = typeof twitter.title === 'string' && twitter.title.trim()
+            ? twitter.title
+            : ogTitle;
+        const twitterDescription = typeof twitter.description === 'string' && twitter.description.trim()
+            ? twitter.description
+            : description;
+        const twitterImage = typeof twitter.image === 'string' && twitter.image.trim()
+            ? twitter.image
+            : ogImage;
+        const twitterSite = typeof twitter.site === 'string' && twitter.site.trim()
+            ? twitter.site
+            : DEFAULT_TWITTER_HANDLE;
+        const twitterCreator = typeof twitter.creator === 'string' && twitter.creator.trim()
+            ? twitter.creator
+            : DEFAULT_TWITTER_HANDLE;
+
+        updateMetaTag(ensureMetaByName('description'), description);
+        updateMetaTag(ensureMetaByName('keywords'), keywords);
+        updateMetaTag(ensureMetaByProperty('og:title'), ogTitle);
+        updateMetaTag(ensureMetaByProperty('og:description'), ogDescription);
+        updateMetaTag(ensureMetaByProperty('og:type'), ogType);
+        updateMetaTag(ensureMetaByProperty('og:url'), canonicalUrl);
+        updateMetaTag(ensureMetaByProperty('og:image'), ogImage);
+        updateMetaTag(ensureMetaByProperty('og:image:alt'), ogImageAlt);
+        updateMetaTag(ensureMetaByProperty('og:site_name'), ogSiteName);
+
+        updateMetaTag(ensureMetaByName('twitter:card'), twitterCard);
+        updateMetaTag(ensureMetaByName('twitter:title'), twitterTitle);
+        updateMetaTag(ensureMetaByName('twitter:description'), twitterDescription);
+        updateMetaTag(ensureMetaByName('twitter:image'), twitterImage);
+        updateMetaTag(ensureMetaByName('twitter:site'), twitterSite);
+        updateMetaTag(ensureMetaByName('twitter:creator'), twitterCreator);
+
+        const canonicalLink = ensureCanonicalLink();
+        if (canonicalLink) {
+            canonicalLink.setAttribute('href', canonicalUrl);
+        }
+
+        return {
+            canonicalUrl,
+            description,
+            keywords,
+            ogTitle,
+            twitterTitle
+        };
+    }
+
+    global.SiteMetadata = {
+        updateForRoute,
+        buildCanonicalUrl
+    };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -12,6 +12,22 @@ const routerRuntime = {
     pageHandlers: Object.create(null)
 };
 
+function updateMetadataForPage(routeConfig, pageTitle, normalizedPageId, loadStatus) {
+    if (typeof SiteMetadata === 'undefined' || !SiteMetadata || typeof SiteMetadata.updateForRoute !== 'function') {
+        return;
+    }
+
+    try {
+        SiteMetadata.updateForRoute(routeConfig, {
+            pageId: normalizedPageId,
+            pageTitle,
+            loadStatus
+        });
+    } catch (error) {
+        console.error('Router: Failed to update metadata:', error);
+    }
+}
+
 function callCallback(callback, description, ...args) {
     if (typeof callback !== 'function') {
         return false;
@@ -156,6 +172,7 @@ async function loadPageContent(pageId, updateHistory = true) {
         pageContentArea.innerHTML = createNotFoundHtml(normalizedPageId);
 
         const notFoundTitle = 'Not Found';
+        updateMetadataForPage(null, notFoundTitle, normalizedPageId, 'not-found');
         if (historyHelper && typeof historyHelper.updateTitle === 'function') {
             historyHelper.updateTitle(appBarHeadline, notFoundTitle);
         } else {
@@ -220,6 +237,8 @@ async function loadPageContent(pageId, updateHistory = true) {
     }
 
     const pageTitle = loadResult.title || (routeConfig && routeConfig.title) || (contentLoader && contentLoader.DEFAULT_PAGE_TITLE) || "Mihai's Profile";
+
+    updateMetadataForPage(routeConfig, pageTitle, normalizedPageId, loadResult.status);
 
     if (historyHelper && typeof historyHelper.updateTitle === 'function') {
         historyHelper.updateTitle(appBarHeadline, pageTitle);

--- a/assets/js/router/routes.js
+++ b/assets/js/router/routes.js
@@ -1,5 +1,18 @@
 (function (global) {
     const DEFAULT_ROUTE_TITLE = "Mihai's Profile";
+    const DEFAULT_METADATA_DESCRIPTION = 'Explore Mihai-Cristian Condrea\'s Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.';
+    const DEFAULT_METADATA_KEYWORDS = [
+        'Mihai Cristian Condrea',
+        'Android developer portfolio',
+        'Jetpack Compose',
+        'Kotlin apps',
+        'Material Design UI'
+    ];
+    const DEFAULT_SOCIAL_IMAGE = 'https://mihaicristiancondrea.github.io/profile/assets/images/profile/cv_profile_pic.png';
+    const DEFAULT_SOCIAL_IMAGE_ALT = 'Portrait of Android developer Mihai-Cristian Condrea';
+    const DEFAULT_OPEN_GRAPH_TYPE = 'website';
+    const DEFAULT_TWITTER_CARD = 'summary_large_image';
+    const DEFAULT_TWITTER_HANDLE = '@MihaiCrstian';
     const PAGE_ROUTES = Object.create(null);
 
     function normalizeRouteId(routeId) {
@@ -11,6 +24,165 @@
             return '';
         }
         return trimmed.startsWith('#') ? trimmed.substring(1) : trimmed;
+    }
+
+    function sanitizeKeywords(value) {
+        if (Array.isArray(value)) {
+            return value
+                .map(keyword => (typeof keyword === 'string' ? keyword.trim() : ''))
+                .filter(Boolean);
+        }
+
+        if (typeof value === 'string') {
+            return value
+                .split(',')
+                .map(keyword => keyword.trim())
+                .filter(Boolean);
+        }
+
+        return [];
+    }
+
+    function sanitizeCanonicalSlug(value, routeId) {
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed || trimmed === '/' || trimmed === '#') {
+                return routeId === 'home' ? '' : routeId;
+            }
+
+            if (/^https?:\/\//i.test(trimmed)) {
+                return trimmed;
+            }
+
+            const normalized = trimmed.replace(/^[/#]+/, '').replace(/[/#]+$/, '');
+            return normalized || (routeId === 'home' ? '' : routeId);
+        }
+
+        return routeId === 'home' ? '' : routeId;
+    }
+
+    function sanitizeOpenGraph(openGraphConfig, route, description) {
+        const config = openGraphConfig && typeof openGraphConfig === 'object' ? openGraphConfig : {};
+
+        const title = typeof config.title === 'string' && config.title.trim()
+            ? config.title.trim()
+            : (route.title || DEFAULT_ROUTE_TITLE);
+
+        const ogDescription = typeof config.description === 'string' && config.description.trim()
+            ? config.description.trim()
+            : description;
+
+        const type = typeof config.type === 'string' && config.type.trim()
+            ? config.type.trim()
+            : DEFAULT_OPEN_GRAPH_TYPE;
+
+        const image = typeof config.image === 'string' && config.image.trim()
+            ? config.image.trim()
+            : DEFAULT_SOCIAL_IMAGE;
+
+        const imageAlt = typeof config.imageAlt === 'string' && config.imageAlt.trim()
+            ? config.imageAlt.trim()
+            : DEFAULT_SOCIAL_IMAGE_ALT;
+
+        const siteName = typeof config.siteName === 'string' && config.siteName.trim()
+            ? config.siteName.trim()
+            : DEFAULT_ROUTE_TITLE;
+
+        return {
+            title,
+            description: ogDescription,
+            type,
+            image,
+            imageAlt,
+            siteName
+        };
+    }
+
+    function sanitizeTwitter(twitterConfig, openGraph, description) {
+        const config = twitterConfig && typeof twitterConfig === 'object' ? twitterConfig : {};
+
+        const card = typeof config.card === 'string' && config.card.trim()
+            ? config.card.trim()
+            : DEFAULT_TWITTER_CARD;
+
+        const title = typeof config.title === 'string' && config.title.trim()
+            ? config.title.trim()
+            : openGraph.title;
+
+        const twitterDescription = typeof config.description === 'string' && config.description.trim()
+            ? config.description.trim()
+            : description;
+
+        const image = typeof config.image === 'string' && config.image.trim()
+            ? config.image.trim()
+            : openGraph.image;
+
+        const site = typeof config.site === 'string' && config.site.trim()
+            ? config.site.trim()
+            : DEFAULT_TWITTER_HANDLE;
+
+        const creator = typeof config.creator === 'string' && config.creator.trim()
+            ? config.creator.trim()
+            : DEFAULT_TWITTER_HANDLE;
+
+        return {
+            card,
+            title,
+            description: twitterDescription,
+            image,
+            site,
+            creator
+        };
+    }
+
+    function sanitizeMetadata(metadataConfig, route) {
+        const config = metadataConfig && typeof metadataConfig === 'object' ? metadataConfig : {};
+
+        const description = typeof config.description === 'string' && config.description.trim()
+            ? config.description.trim()
+            : DEFAULT_METADATA_DESCRIPTION;
+
+        const keywords = sanitizeKeywords(config.keywords);
+        const canonicalSlug = sanitizeCanonicalSlug(config.canonicalSlug, route.id);
+        const openGraph = sanitizeOpenGraph(config.openGraph, route, description);
+        const twitter = sanitizeTwitter(config.twitter, openGraph, description);
+
+        return {
+            description,
+            keywords: keywords.length ? keywords : [...DEFAULT_METADATA_KEYWORDS],
+            canonicalSlug,
+            openGraph,
+            twitter
+        };
+    }
+
+    function cloneMetadata(metadata) {
+        if (!metadata || typeof metadata !== 'object') {
+            return null;
+        }
+
+        return {
+            description: metadata.description,
+            keywords: Array.isArray(metadata.keywords) ? [...metadata.keywords] : [],
+            canonicalSlug: metadata.canonicalSlug,
+            openGraph: metadata.openGraph && typeof metadata.openGraph === 'object'
+                ? { ...metadata.openGraph }
+                : null,
+            twitter: metadata.twitter && typeof metadata.twitter === 'object'
+                ? { ...metadata.twitter }
+                : null
+        };
+    }
+
+    function cloneRoute(route) {
+        if (!route || typeof route !== 'object') {
+            return null;
+        }
+
+        return {
+            ...route,
+            metadata: cloneMetadata(route.metadata)
+        };
     }
 
     function sanitizeRouteConfig(config) {
@@ -30,6 +202,8 @@
             onLoad: typeof config.onLoad === 'function' ? config.onLoad : null
         };
 
+        sanitized.metadata = sanitizeMetadata(config.metadata, sanitized);
+
         return sanitized;
     }
 
@@ -40,7 +214,7 @@
         if (isUpdate) {
             console.warn(`RouterRoutes: Route "${sanitized.id}" was overwritten.`);
         }
-        return { ...sanitized };
+        return cloneRoute(sanitized);
     }
 
     function getRoute(routeId) {
@@ -48,7 +222,8 @@
         if (!normalizedId) {
             return null;
         }
-        return PAGE_ROUTES[normalizedId] || null;
+        const storedRoute = PAGE_ROUTES[normalizedId];
+        return cloneRoute(storedRoute);
     }
 
     function hasRoute(routeId) {
@@ -56,7 +231,7 @@
     }
 
     function getRoutes() {
-        return Object.values(PAGE_ROUTES).map(route => ({ ...route }));
+        return Object.values(PAGE_ROUTES).map(route => cloneRoute(route));
     }
 
     function runHomeOnLoad() {
@@ -92,26 +267,298 @@
     }
 
     const defaultRoutes = [
-        { id: 'home', title: DEFAULT_ROUTE_TITLE, onLoad: runHomeOnLoad },
-        { id: 'privacy-policy', path: 'pages/drawer/more/privacy-policy.html', title: 'Privacy Policy' },
-        { id: 'songs', path: 'pages/drawer/songs.html', title: 'My Music', onLoad: runSongsOnLoad },
-        { id: 'projects', path: 'pages/drawer/projects.html', title: 'Projects', onLoad: runProjectsOnLoad },
-        { id: 'contact', path: 'pages/drawer/contact.html', title: 'Contact' },
-        { id: 'about-me', path: 'pages/drawer/about-me.html', title: 'About Me' },
-        { id: 'ads-help-center', path: 'pages/drawer/more/apps/ads-help-center.html', title: 'Ads Help Center' },
-        { id: 'legal-notices', path: 'pages/drawer/more/apps/legal-notices.html', title: 'Legal Notices' },
-        { id: 'code-of-conduct', path: 'pages/drawer/more/code-of-conduct.html', title: 'Code of Conduct' },
+        {
+            id: 'home',
+            title: DEFAULT_ROUTE_TITLE,
+            onLoad: runHomeOnLoad,
+            metadata: {
+                description: 'Explore Mihai-Cristian Condrea\'s Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.',
+                keywords: [
+                    'Mihai Cristian Condrea',
+                    'Android developer portfolio',
+                    'Jetpack Compose apps',
+                    'Kotlin UI design',
+                    'Material You projects'
+                ],
+                canonicalSlug: '/',
+                openGraph: {
+                    title: 'Mihai-Cristian Condrea | Android Developer Portfolio',
+                    description: 'Explore Mihai-Cristian Condrea\'s Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.',
+                    type: 'website'
+                },
+                twitter: {
+                    title: 'Mihai-Cristian Condrea | Android Developer Portfolio',
+                    description: 'Explore Mihai-Cristian Condrea\'s Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.'
+                }
+            }
+        },
+        {
+            id: 'privacy-policy',
+            path: 'pages/drawer/more/privacy-policy.html',
+            title: 'Privacy Policy',
+            metadata: {
+                description: 'Review the website privacy policy for Mihai-Cristian Condrea\'s personal site covering analytics, local storage preferences, and data protection practices.',
+                keywords: [
+                    'Mihai Cristian Condrea privacy policy',
+                    'website data protection',
+                    'analytics disclosure',
+                    'local storage preferences'
+                ],
+                canonicalSlug: 'privacy-policy',
+                openGraph: {
+                    title: 'Website Privacy Policy | Mihai-Cristian Condrea',
+                    description: 'Review the website privacy policy for Mihai-Cristian Condrea\'s personal site covering analytics, local storage preferences, and data protection practices.',
+                    type: 'article'
+                },
+                twitter: {
+                    title: 'Website Privacy Policy | Mihai-Cristian Condrea',
+                    description: 'Review the website privacy policy for Mihai-Cristian Condrea\'s personal site covering analytics, local storage preferences, and data protection practices.'
+                }
+            }
+        },
+        {
+            id: 'songs',
+            path: 'pages/drawer/songs.html',
+            title: 'My Music',
+            onLoad: runSongsOnLoad,
+            metadata: {
+                description: 'Listen to Mihai-Cristian Condrea\'s original tracks and playlists, including ambient production, electronic experiments, and featured collaborations.',
+                keywords: [
+                    'Mihai Cristian Condrea music',
+                    'D4rK Rekords tracks',
+                    'ambient electronic producer',
+                    'indie Android developer musician'
+                ],
+                canonicalSlug: 'songs',
+                openGraph: {
+                    title: 'My Music | Mihai-Cristian Condrea',
+                    description: 'Listen to Mihai-Cristian Condrea\'s original tracks and playlists, including ambient production, electronic experiments, and featured collaborations.',
+                    type: 'music.playlist'
+                },
+                twitter: {
+                    title: 'My Music | Mihai-Cristian Condrea',
+                    description: 'Listen to Mihai-Cristian Condrea\'s original tracks and playlists, including ambient production, electronic experiments, and featured collaborations.'
+                }
+            }
+        },
+        {
+            id: 'projects',
+            path: 'pages/drawer/projects.html',
+            title: 'Projects',
+            onLoad: runProjectsOnLoad,
+            metadata: {
+                description: 'Discover Mihai-Cristian Condrea\'s Android and web projects featuring Jetpack Compose demos, Material You UI patterns, and open-source utilities.',
+                keywords: [
+                    'Jetpack Compose portfolio',
+                    'Android app showcase',
+                    'Material You case studies',
+                    'Mihai Cristian Condrea projects'
+                ],
+                canonicalSlug: 'projects',
+                openGraph: {
+                    title: 'Projects | Mihai-Cristian Condrea',
+                    description: 'Discover Mihai-Cristian Condrea\'s Android and web projects featuring Jetpack Compose demos, Material You UI patterns, and open-source utilities.',
+                    type: 'website'
+                },
+                twitter: {
+                    title: 'Projects | Mihai-Cristian Condrea',
+                    description: 'Discover Mihai-Cristian Condrea\'s Android and web projects featuring Jetpack Compose demos, Material You UI patterns, and open-source utilities.'
+                }
+            }
+        },
+        {
+            id: 'contact',
+            path: 'pages/drawer/contact.html',
+            title: 'Contact',
+            metadata: {
+                description: 'Contact Mihai-Cristian Condrea to discuss Android development collaborations, UI design engagements, or support for open-source apps.',
+                keywords: [
+                    'contact Mihai Cristian Condrea',
+                    'hire Android developer Romania',
+                    'Jetpack Compose collaboration',
+                    'open source app support'
+                ],
+                canonicalSlug: 'contact',
+                openGraph: {
+                    title: 'Contact Mihai | Android Developer',
+                    description: 'Contact Mihai-Cristian Condrea to discuss Android development collaborations, UI design engagements, or support for open-source apps.',
+                    type: 'website'
+                },
+                twitter: {
+                    title: 'Contact Mihai | Android Developer',
+                    description: 'Contact Mihai-Cristian Condrea to discuss Android development collaborations, UI design engagements, or support for open-source apps.'
+                }
+            }
+        },
+        {
+            id: 'about-me',
+            path: 'pages/drawer/about-me.html',
+            title: 'About Me',
+            metadata: {
+                description: 'Learn about Mihai-Cristian Condrea, a Bucharest-based Android developer crafting Jetpack Compose apps, Material Design systems, and community tutorials.',
+                keywords: [
+                    'Mihai Cristian Condrea biography',
+                    'Bucharest Android developer',
+                    'Jetpack Compose expert',
+                    'Material Design UI engineer'
+                ],
+                canonicalSlug: 'about-me',
+                openGraph: {
+                    title: 'About Mihai-Cristian Condrea',
+                    description: 'Learn about Mihai-Cristian Condrea, a Bucharest-based Android developer crafting Jetpack Compose apps, Material Design systems, and community tutorials.',
+                    type: 'profile'
+                },
+                twitter: {
+                    title: 'About Mihai-Cristian Condrea',
+                    description: 'Learn about Mihai-Cristian Condrea, a Bucharest-based Android developer crafting Jetpack Compose apps, Material Design systems, and community tutorials.'
+                }
+            }
+        },
+        {
+            id: 'ads-help-center',
+            path: 'pages/drawer/more/apps/ads-help-center.html',
+            title: 'Ads Help Center',
+            metadata: {
+                description: 'Understand how Mihai-Cristian Condrea integrates advertising across Android apps, including consent flows, personalization controls, and GDPR compliance.',
+                keywords: [
+                    'Mihai Cristian Condrea ads help',
+                    'Android app advertising transparency',
+                    'Consent mode v2 guidance',
+                    'GDPR compliant mobile ads'
+                ],
+                canonicalSlug: 'ads-help-center',
+                openGraph: {
+                    title: 'Advertising Transparency | Mihai-Cristian Condrea',
+                    description: 'Understand how Mihai-Cristian Condrea integrates advertising across Android apps, including consent flows, personalization controls, and GDPR compliance.',
+                    type: 'article'
+                },
+                twitter: {
+                    title: 'Advertising Transparency | Mihai-Cristian Condrea',
+                    description: 'Understand how Mihai-Cristian Condrea integrates advertising across Android apps, including consent flows, personalization controls, and GDPR compliance.'
+                }
+            }
+        },
+        {
+            id: 'legal-notices',
+            path: 'pages/drawer/more/apps/legal-notices.html',
+            title: 'Legal Notices',
+            metadata: {
+                description: 'Review software licenses and third-party acknowledgments for Mihai-Cristian Condrea\'s Android and web applications.',
+                keywords: [
+                    'Mihai Cristian Condrea legal notices',
+                    'third party licenses Android apps',
+                    'open source acknowledgments',
+                    'software attribution list'
+                ],
+                canonicalSlug: 'legal-notices',
+                openGraph: {
+                    title: 'Legal Notices | Mihai-Cristian Condrea',
+                    description: 'Review software licenses and third-party acknowledgments for Mihai-Cristian Condrea\'s Android and web applications.',
+                    type: 'article'
+                },
+                twitter: {
+                    title: 'Legal Notices | Mihai-Cristian Condrea',
+                    description: 'Review software licenses and third-party acknowledgments for Mihai-Cristian Condrea\'s Android and web applications.'
+                }
+            }
+        },
+        {
+            id: 'code-of-conduct',
+            path: 'pages/drawer/more/code-of-conduct.html',
+            title: 'Code of Conduct',
+            metadata: {
+                description: 'Read the community code of conduct guiding respectful collaboration across Mihai-Cristian Condrea\'s projects and communication channels.',
+                keywords: [
+                    'Mihai Cristian Condrea code of conduct',
+                    'open source community guidelines',
+                    'inclusive collaboration standards',
+                    'developer communication policy'
+                ],
+                canonicalSlug: 'code-of-conduct',
+                openGraph: {
+                    title: 'Code of Conduct | Mihai-Cristian Condrea',
+                    description: 'Read the community code of conduct guiding respectful collaboration across Mihai-Cristian Condrea\'s projects and communication channels.',
+                    type: 'article'
+                },
+                twitter: {
+                    title: 'Code of Conduct | Mihai-Cristian Condrea',
+                    description: 'Read the community code of conduct guiding respectful collaboration across Mihai-Cristian Condrea\'s projects and communication channels.'
+                }
+            }
+        },
         {
             id: 'privacy-policy-end-user-software',
             path: 'pages/drawer/more/apps/privacy-policy-apps.html',
-            title: 'Privacy Policy – End-User Software'
+            title: 'Privacy Policy – End-User Software',
+            metadata: {
+                description: 'Review the privacy policy for Mihai-Cristian Condrea\'s Android applications covering analytics, consent mode, advertising IDs, and crash reporting.',
+                keywords: [
+                    'Android app privacy policy',
+                    'Mihai Cristian Condrea software privacy',
+                    'Firebase analytics consent',
+                    'AdMob data usage disclosure'
+                ],
+                canonicalSlug: 'privacy-policy-end-user-software',
+                openGraph: {
+                    title: 'Android App Privacy Policy | Mihai-Cristian Condrea',
+                    description: 'Review the privacy policy for Mihai-Cristian Condrea\'s Android applications covering analytics, consent mode, advertising IDs, and crash reporting.',
+                    type: 'article'
+                },
+                twitter: {
+                    title: 'Android App Privacy Policy | Mihai-Cristian Condrea',
+                    description: 'Review the privacy policy for Mihai-Cristian Condrea\'s Android applications covering analytics, consent mode, advertising IDs, and crash reporting.'
+                }
+            }
         },
         {
             id: 'terms-of-service-end-user-software',
             path: 'pages/drawer/more/apps/terms-of-service-apps.html',
-            title: 'Terms of Service – End-User Software'
+            title: 'Terms of Service – End-User Software',
+            metadata: {
+                description: 'Understand the terms of service governing Mihai-Cristian Condrea\'s Android apps, including licensing, in-app purchases, and user responsibilities.',
+                keywords: [
+                    'Android app terms of service',
+                    'Mihai Cristian Condrea app license',
+                    'in-app purchase policy',
+                    'user responsibilities mobile apps'
+                ],
+                canonicalSlug: 'terms-of-service-end-user-software',
+                openGraph: {
+                    title: 'Android App Terms of Service | Mihai-Cristian Condrea',
+                    description: 'Understand the terms of service governing Mihai-Cristian Condrea\'s Android apps, including licensing, in-app purchases, and user responsibilities.',
+                    type: 'article'
+                },
+                twitter: {
+                    title: 'Android App Terms of Service | Mihai-Cristian Condrea',
+                    description: 'Understand the terms of service governing Mihai-Cristian Condrea\'s Android apps, including licensing, in-app purchases, and user responsibilities.'
+                }
+            }
         },
-        { id: 'resume', path: 'pages/resume/resume.html', title: "Mihai's Resume", onLoad: runResumeOnLoad }
+        {
+            id: 'resume',
+            path: 'pages/resume/resume.html',
+            title: "Mihai's Resume",
+            onLoad: runResumeOnLoad,
+            metadata: {
+                description: 'Use Mihai-Cristian Condrea\'s interactive resume builder to assemble, preview, and download a polished CV template for Android developers.',
+                keywords: [
+                    'Android developer resume builder',
+                    'Mihai Cristian Condrea CV template',
+                    'Jetpack Compose resume generator',
+                    'download professional resume PDF'
+                ],
+                canonicalSlug: 'resume',
+                openGraph: {
+                    title: 'Resume Builder | Mihai-Cristian Condrea',
+                    description: 'Use Mihai-Cristian Condrea\'s interactive resume builder to assemble, preview, and download a polished CV template for Android developers.',
+                    type: 'website'
+                },
+                twitter: {
+                    title: 'Resume Builder | Mihai-Cristian Condrea',
+                    description: 'Use Mihai-Cristian Condrea\'s interactive resume builder to assemble, preview, and download a polished CV template for Android developers.'
+                }
+            }
+        }
     ];
 
     defaultRoutes.forEach(registerRoute);

--- a/index.html
+++ b/index.html
@@ -5,11 +5,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Mihai's Profile</title>
-    <meta name="description" content="Personal profile site of Mihai-Cristian Condrea featuring projects, music, and more.">
-    <meta property="og:title" content="Mihai's Profile">
-    <meta property="og:description" content="Personal profile site of Mihai-Cristian Condrea featuring projects, music, and more.">
+    <meta name="description" content="Explore Mihai-Cristian Condrea's Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.">
+    <meta name="keywords" content="Mihai Cristian Condrea, Android developer portfolio, Jetpack Compose apps, Kotlin UI design, Material You projects">
+    <meta property="og:title" content="Mihai-Cristian Condrea | Android Developer Portfolio">
+    <meta property="og:description" content="Explore Mihai-Cristian Condrea's Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.">
+    <meta property="og:type" content="website">
     <meta property="og:image" content="https://mihaicristiancondrea.github.io/profile/assets/images/profile/cv_profile_pic.png">
+    <meta property="og:image:alt" content="Portrait of Android developer Mihai-Cristian Condrea">
     <meta property="og:url" content="https://mihaicristiancondrea.github.io/profile/">
+    <meta property="og:site_name" content="Mihai's Profile">
+    <link rel="canonical" href="https://mihaicristiancondrea.github.io/profile/">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Mihai-Cristian Condrea | Android Developer Portfolio">
+    <meta name="twitter:description" content="Explore Mihai-Cristian Condrea's Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.">
+    <meta name="twitter:image" content="https://mihaicristiancondrea.github.io/profile/assets/images/profile/cv_profile_pic.png">
+    <meta name="twitter:site" content="@MihaiCrstian">
+    <meta name="twitter:creator" content="@MihaiCrstian">
     <link rel="icon" href="assets/icons/favicon.ico" sizes="any">
     <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png">
     <link rel="manifest" href="assets/manifest.json">
@@ -289,6 +300,7 @@
     <script src="assets/js/router/animation.js" defer></script>
     <script src="assets/js/animations.js" defer></script>
     <script src="assets/js/router/contentLoader.js" defer></script>
+    <script src="assets/js/metadataManager.js" defer></script>
     <script src="assets/js/router/history.js" defer></script>
     <script src="assets/js/router.js" defer></script>
     <script src="assets/js/committers.js" defer></script>


### PR DESCRIPTION
## Summary
- extend the router registry to sanitize metadata for each route and populate rich SEO fields for existing pages
- introduce a metadata manager that syncs description, keyword, Open Graph, Twitter, and canonical tags during navigation and wire it into the router
- refresh the static head tags, document the workflow in the README, and cover the new behaviour with Jest tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce5a84e62c832da8b1c9822b46c00e