### PR TITLE
Support resume edit mode query in hash URLs

### DIFF
--- a/__tests__/resume.test.js
+++ b/__tests__/resume.test.js
@@ -257,4 +257,19 @@ describe('resume.js browser integration', () => {
     await runInitResumePage();
     expect(document.querySelector('#resumePage .form-container').style.display).toBe('none');
   });
+
+  test('respects edit query parameter provided inside the hash fragment', async () => {
+    window.history.replaceState({}, '', 'http://localhost/#resume?edit=true');
+    await runInitResumePage();
+    expect(document.querySelector('#resumePage .form-container').style.display).not.toBe('none');
+
+    document.head.innerHTML = '';
+    document.body.innerHTML = baseMarkup;
+    document.fonts = { ready: Promise.resolve() };
+    window.marked.parse.mockClear();
+    window.DOMPurify.sanitize.mockClear();
+    window.history.replaceState({}, '', 'http://localhost/#resume?edit=false');
+    await runInitResumePage();
+    expect(document.querySelector('#resumePage .form-container').style.display).toBe('none');
+  });
 });

--- a/assets/js/resume.js
+++ b/assets/js/resume.js
@@ -163,11 +163,46 @@ function initialize() {
     document.getElementById('photo-preview').style.backgroundImage = "url('assets/images/profile/cv_profile_pic.png')";
 }
 
+function getResumeEditParam() {
+    if (typeof window === 'undefined' || !window.location) {
+        return null;
+    }
+
+    const parseParams = (paramString) => {
+        if (typeof paramString !== 'string' || paramString.length === 0) {
+            return null;
+        }
+        const params = new URLSearchParams(paramString);
+        return params.has('edit') ? params.get('edit') : null;
+    };
+
+    const searchValue = parseParams(window.location.search);
+    if (searchValue !== null) {
+        return searchValue;
+    }
+
+    const hash = window.location.hash;
+    if (typeof hash === 'string' && hash.length > 0) {
+        const queryStart = hash.search(/[?&]/);
+        if (queryStart !== -1) {
+            const hashParams = hash.slice(queryStart + 1);
+            const hashValue = parseParams(hashParams);
+            if (hashValue !== null) {
+                return hashValue;
+            }
+        }
+    }
+
+    return null;
+}
+
 function setupMode() {
-    const params = new URLSearchParams(window.location.search);
-    const editMode = params.get('edit') === 'true';
+    const editValue = getResumeEditParam();
+    const editMode = typeof editValue === 'string' && editValue.toLowerCase() === 'true';
     const form = document.querySelector('#resumePage .form-container');
-    if (!editMode && form) form.style.display = 'none';
+    if (form) {
+        form.style.display = editMode ? '' : 'none';
+    }
 }
 
 function prepareAndPrintResume() {


### PR DESCRIPTION
## Summary
- update resume edit mode detection to read the `edit` parameter from either the URL search string or hash fragment
- ensure the resume form display toggles reliably based on the normalized boolean value
- add regression coverage for hash-based edit parameters in the resume tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce68e4123c832d9b5a0d7fee99ed6f