### PR TITLE
Add new page indicator icon for Blogs drawer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
                 <md-list-item href="https://d4rk7355608.blogspot.com/" target="_blank" rel="noopener noreferrer">
                     <md-icon slot="start"><span class="material-symbols-outlined">article</span></md-icon>
                     <div slot="headline">Blogs</div>
+                    <md-icon slot="end"><span class="material-symbols-outlined">open_in_new</span></md-icon>
                 </md-list-item>
                 <md-list-item href="#songs" id="navSongsLink">
                     <md-icon slot="start"><span class="material-symbols-outlined">music_note</span></md-icon>


### PR DESCRIPTION
## Summary
- add an `open_in_new` icon to the Blogs entry in the navigation drawer to signal it opens a new page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6d859fd4832da5501b9e52fa553b