### PR TITLE
Refine motion system for smoother adaptive animations

### DIFF
--- a/assets/js/animations.js
+++ b/assets/js/animations.js
@@ -13,6 +13,7 @@
     if (reduceMotionQuery) {
         const updatePreference = (event) => {
             prefersReducedMotion = !!(event && event.matches);
+            updateMotionPreferenceClasses();
         };
 
         if (typeof reduceMotionQuery.addEventListener === 'function') {
@@ -22,8 +23,12 @@
         }
     }
 
-    function animationsEnabled() {
-        return hasWaapiSupport && !prefersReducedMotion;
+    function canAnimate() {
+        return hasWaapiSupport;
+    }
+
+    function shouldReduceMotion() {
+        return prefersReducedMotion;
     }
 
     function cleanupElementStyles(element, immediate = false) {
@@ -51,28 +56,52 @@
         return [value];
     }
 
+    function updateMotionPreferenceClasses() {
+        if (!root || !root.documentElement) {
+            return;
+        }
+
+        const htmlElement = root.documentElement;
+        const reduce = shouldReduceMotion();
+
+        if (reduce) {
+            htmlElement.classList.add('prefers-reduced-motion');
+        } else {
+            htmlElement.classList.remove('prefers-reduced-motion');
+        }
+
+        htmlElement.classList.toggle('animations-enabled', canAnimate() && !reduce);
+    }
+
     const KEYFRAMES = {
         hero: [
-            { opacity: 0, transform: 'translateY(32px) scale(0.96)', filter: 'blur(10px)' },
+            { opacity: 0, transform: 'translateY(24px) scale(0.97)', filter: 'blur(6px)' },
             { opacity: 1, transform: 'translateY(0) scale(1)', filter: 'blur(0)' }
         ],
         rise: [
-            { opacity: 0, transform: 'translateY(20px)', filter: 'blur(6px)' },
+            { opacity: 0, transform: 'translateY(18px)', filter: 'blur(4px)' },
             { opacity: 1, transform: 'translateY(0)', filter: 'blur(0)' }
         ],
         subtleRise: [
-            { opacity: 0, transform: 'translateY(16px)', filter: 'blur(4px)' },
+            { opacity: 0, transform: 'translateY(12px)', filter: 'blur(2px)' },
             { opacity: 1, transform: 'translateY(0)', filter: 'blur(0)' }
         ],
         pop: [
-            { opacity: 0, transform: 'scale(0.85)', filter: 'blur(4px)' },
-            { opacity: 1, transform: 'scale(1)', filter: 'blur(0)' }
+            { opacity: 0, transform: 'translateY(8px) scale(0.94)', filter: 'blur(2px)' },
+            { opacity: 1, transform: 'translateY(0) scale(1)', filter: 'blur(0)' }
         ],
         slideInRight: [
-            { opacity: 0, transform: 'translateX(-28px)', filter: 'blur(4px)' },
+            { opacity: 0, transform: 'translateX(-20px)', filter: 'blur(3px)' },
             { opacity: 1, transform: 'translateX(0)', filter: 'blur(0)' }
         ]
     };
+
+    const REDUCED_KEYFRAMES = Object.freeze({
+        fade: [
+            { opacity: 0 },
+            { opacity: 1 }
+        ]
+    });
 
     const LINEAR_EASINGS = Object.freeze({
         accelerate: 'linear(0, 0.003 3.8%, 0.011 7.7%, 0.025 11.7%, 0.043 15.8%, 0.066 19.9%, 0.092 24.1%, 0.123 28.3%, 0.156 32.5%, 0.193 36.7%, 0.232 40.9%, 0.273 45.1%, 0.316 49.2%, 0.407 57.3%, 0.5 65%, 0.593 72.2%, 0.684 78.9%, 0.768 84.9%, 0.844 90%, 0.957 97.3%, 1)',
@@ -98,35 +127,240 @@
         return fallback;
     }
 
-    function animateElement(element, keyframes, options) {
+    const DEFAULT_MOTION_TOKEN = Object.freeze({
+        duration: 480,
+        easing: LINEAR_EASINGS.decelerate,
+        fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+        reducedDuration: 220
+    });
+
+    const DEFAULT_MOTION_SCHEME = 'expressive';
+
+    const MOTION_SCHEMES = Object.freeze({
+        expressive: {
+            spatial: {
+                fast: {
+                    duration: 260,
+                    easing: LINEAR_EASINGS.bounce,
+                    fallbackEasing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+                    reducedDuration: 160
+                },
+                default: {
+                    duration: 520,
+                    easing: LINEAR_EASINGS.spring,
+                    fallbackEasing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+                    reducedDuration: 220
+                },
+                slow: {
+                    duration: 720,
+                    easing: LINEAR_EASINGS.spring,
+                    fallbackEasing: 'cubic-bezier(0.22, 1, 0.36, 1)',
+                    reducedDuration: 260
+                }
+            },
+            effect: {
+                fast: {
+                    duration: 200,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 160
+                },
+                default: {
+                    duration: 320,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 200
+                },
+                slow: {
+                    duration: 420,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 240
+                }
+            }
+        },
+        standard: {
+            spatial: {
+                fast: {
+                    duration: 220,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 150
+                },
+                default: {
+                    duration: 420,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 200
+                },
+                slow: {
+                    duration: 520,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 240
+                }
+            },
+            effect: {
+                fast: {
+                    duration: 160,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 120
+                },
+                default: {
+                    duration: 240,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 160
+                },
+                slow: {
+                    duration: 320,
+                    easing: LINEAR_EASINGS.decelerate,
+                    fallbackEasing: CUBIC_EASING_FALLBACKS.decelerate,
+                    reducedDuration: 200
+                }
+            }
+        }
+    });
+
+    let activeMotionScheme = DEFAULT_MOTION_SCHEME;
+    let currentMotionSchemeClass = '';
+
+    function getMotionScheme() {
+        return activeMotionScheme;
+    }
+
+    function applyMotionSchemeAttributes() {
+        if (!root || !root.documentElement) {
+            return;
+        }
+
+        const htmlElement = root.documentElement;
+        if (currentMotionSchemeClass) {
+            htmlElement.classList.remove(currentMotionSchemeClass);
+        }
+
+        currentMotionSchemeClass = `motion-scheme-${activeMotionScheme}`;
+        htmlElement.classList.add(currentMotionSchemeClass);
+        htmlElement.dataset.motionScheme = activeMotionScheme;
+    }
+
+    function setMotionScheme(schemeName) {
+        if (!schemeName || !MOTION_SCHEMES[schemeName]) {
+            return activeMotionScheme;
+        }
+
+        activeMotionScheme = schemeName;
+        applyMotionSchemeAttributes();
+        return activeMotionScheme;
+    }
+
+    function resolveMotionSpec(meta) {
+        const motionMeta = meta && typeof meta === 'object' ? meta : {};
+        const type = motionMeta.type === 'effect' ? 'effect' : 'spatial';
+        const speed = motionMeta.speed === 'fast' || motionMeta.speed === 'slow'
+            ? motionMeta.speed
+            : 'default';
+
+        const requestedScheme = motionMeta.scheme && MOTION_SCHEMES[motionMeta.scheme]
+            ? motionMeta.scheme
+            : getMotionScheme();
+        const scheme = MOTION_SCHEMES[requestedScheme] || MOTION_SCHEMES[DEFAULT_MOTION_SCHEME];
+        const bucket = scheme[type] || scheme.spatial;
+        const token = (bucket && bucket[speed]) || (bucket && bucket.default) || DEFAULT_MOTION_TOKEN;
+
+        return {
+            duration: typeof token.duration === 'number' ? token.duration : DEFAULT_MOTION_TOKEN.duration,
+            easing: token.easing || DEFAULT_MOTION_TOKEN.easing,
+            fallbackEasing: token.fallbackEasing || DEFAULT_MOTION_TOKEN.fallbackEasing,
+            reducedDuration: typeof token.reducedDuration === 'number'
+                ? token.reducedDuration
+                : DEFAULT_MOTION_TOKEN.reducedDuration
+        };
+    }
+
+    function getReducedKeyframes(frames) {
+        const normalizedFrames = Array.isArray(frames) ? frames : [frames];
+        const lastFrame = normalizedFrames[normalizedFrames.length - 1] || {};
+        const finalOpacity = typeof lastFrame.opacity === 'number' ? lastFrame.opacity : 1;
+        return [
+            { opacity: 0 },
+            { opacity: finalOpacity }
+        ];
+    }
+
+    function getAdaptiveStagger(baseGap) {
+        let computedGap = typeof baseGap === 'number' ? baseGap : 0;
+
+        if (root && root.documentElement) {
+            const width = root.documentElement.clientWidth || 0;
+            if (width >= 1440) {
+                computedGap = Math.round(computedGap * 1.25);
+            } else if (width <= 480) {
+                computedGap = Math.round(computedGap * 0.8);
+            }
+        }
+
+        if (shouldReduceMotion()) {
+            computedGap = Math.max(0, Math.min(120, Math.round(computedGap * 0.55)));
+        }
+
+        return computedGap;
+    }
+
+    function animateElement(element, keyframes, options, motionMeta) {
         if (!element) {
             return null;
         }
 
-        if (!animationsEnabled()) {
+        if (!canAnimate()) {
             cleanupElementStyles(element, true);
             return null;
         }
 
-        const frames = Array.isArray(keyframes) ? keyframes : [keyframes];
+        const hasReducedMotion = shouldReduceMotion();
+        const framesInput = Array.isArray(keyframes) ? keyframes : [keyframes];
+        const frames = hasReducedMotion ? getReducedKeyframes(framesInput) : framesInput;
+        const motionSpec = resolveMotionSpec(motionMeta);
+
         const animationOptions = Object.assign({
-            duration: 600,
-            easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.22, 1, 0.36, 1)'),
             fill: 'both'
         }, options || {});
+
+        if (animationOptions.duration === undefined) {
+            animationOptions.duration = motionSpec.duration;
+        }
+
+        const resolvedFallback = motionSpec.fallbackEasing || DEFAULT_MOTION_TOKEN.fallbackEasing;
+        const baseEasing = animationOptions.easing === undefined
+            ? motionSpec.easing
+            : animationOptions.easing;
+        animationOptions.easing = resolveEasing(baseEasing, resolvedFallback);
+
+        if (hasReducedMotion) {
+            const reducedDuration = motionSpec.reducedDuration || DEFAULT_MOTION_TOKEN.reducedDuration;
+            if (typeof reducedDuration === 'number') {
+                animationOptions.duration = Math.min(animationOptions.duration, reducedDuration);
+            }
+            animationOptions.easing = resolveEasing(LINEAR_EASINGS.decelerate, CUBIC_EASING_FALLBACKS.decelerate);
+        }
 
         if (element.style) {
             const firstFrame = frames[0] || {};
             if (firstFrame.opacity !== undefined) {
                 element.style.opacity = firstFrame.opacity;
             }
-            if (firstFrame.transform !== undefined) {
+            if (!hasReducedMotion && firstFrame.transform !== undefined) {
                 element.style.transform = firstFrame.transform;
+            } else if (hasReducedMotion) {
+                element.style.transform = '';
             }
-            if (firstFrame.filter !== undefined) {
+            if (!hasReducedMotion && firstFrame.filter !== undefined) {
                 element.style.filter = firstFrame.filter;
+            } else if (hasReducedMotion) {
+                element.style.filter = '';
             }
-            element.style.willChange = 'opacity, transform';
+            element.style.willChange = hasReducedMotion ? 'opacity' : 'opacity, transform';
         }
 
         try {
@@ -144,17 +378,19 @@
         }
     }
 
-    function animateSequence(elements, keyframes, options, gap = 80) {
+    function animateSequence(elements, keyframes, options, gap = 80, motionMeta) {
         const nodes = coerceArray(elements).filter(Boolean);
         if (nodes.length === 0) {
             return;
         }
 
+        const computedGap = getAdaptiveStagger(typeof gap === 'number' ? gap : 0);
+
         nodes.forEach((element, index) => {
             const baseOptions = Object.assign({}, options || {});
             const existingDelay = typeof baseOptions.delay === 'number' ? baseOptions.delay : 0;
-            baseOptions.delay = existingDelay + index * gap;
-            animateElement(element, keyframes, baseOptions);
+            baseOptions.delay = existingDelay + index * computedGap;
+            animateElement(element, keyframes, baseOptions, motionMeta);
         });
     }
 
@@ -165,29 +401,33 @@
 
         const heroCard = container.querySelector('.profile-card');
         if (heroCard) {
-            animateElement(heroCard, KEYFRAMES.hero, {
-                duration: 720,
-                easing: resolveEasing(LINEAR_EASINGS.bounce, 'cubic-bezier(0.22, 1, 0.36, 1)')
+            animateElement(heroCard, KEYFRAMES.hero, null, {
+                scheme: 'expressive',
+                type: 'spatial',
+                speed: 'slow'
             });
         }
 
         const chipElements = container.querySelectorAll('md-chip-set md-assist-chip');
-        animateSequence(chipElements, KEYFRAMES.pop, {
-            duration: 360,
-            easing: resolveEasing(LINEAR_EASINGS.bounce, 'cubic-bezier(0.34, 1.56, 0.64, 1)')
-        }, 40);
+        animateSequence(chipElements, KEYFRAMES.pop, { delay: 40 }, 40, {
+            scheme: 'expressive',
+            type: 'spatial',
+            speed: 'fast'
+        });
 
         const supportingSections = container.querySelectorAll('.achievement-card, .profile-card-actions, .podcast-embed, .news-section, .contribute-card');
-        animateSequence(supportingSections, KEYFRAMES.rise, {
-            duration: 640,
-            easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.22, 1, 0.36, 1)')
-        }, 90);
+        animateSequence(supportingSections, KEYFRAMES.rise, { delay: 80 }, 96, {
+            scheme: 'expressive',
+            type: 'spatial',
+            speed: 'default'
+        });
 
         const socialLinks = container.querySelectorAll('.social-icons a');
-        animateSequence(socialLinks, KEYFRAMES.pop, {
-            duration: 420,
-            easing: resolveEasing(LINEAR_EASINGS.bounce, 'cubic-bezier(0.34, 1.56, 0.64, 1)')
-        }, 50);
+        animateSequence(socialLinks, KEYFRAMES.pop, { delay: 120 }, 48, {
+            scheme: 'expressive',
+            type: 'spatial',
+            speed: 'fast'
+        });
     }
 
     function animateResume(container) {
@@ -198,26 +438,27 @@
         }
 
         const formSections = resumePage.querySelectorAll('.form-container .form-section, .form-container h1');
-        animateSequence(formSections, KEYFRAMES.slideInRight, {
-            duration: 560,
-            easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.16, 1, 0.3, 1)')
-        }, 70);
+        animateSequence(formSections, KEYFRAMES.slideInRight, { delay: 24 }, 70, {
+            scheme: 'standard',
+            type: 'spatial',
+            speed: 'default'
+        });
 
         const previewPanel = resumePage.querySelector('#resume-preview .resume-content');
         if (previewPanel) {
-            animateElement(previewPanel, KEYFRAMES.hero, {
-                duration: 700,
-                easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.16, 1, 0.3, 1)'),
-                delay: 120
+            animateElement(previewPanel, KEYFRAMES.hero, { delay: 120 }, {
+                scheme: 'standard',
+                type: 'spatial',
+                speed: 'slow'
             });
         }
 
         const downloadButton = resumePage.querySelector('button[onclick="prepareAndPrintResume()"]');
         if (downloadButton) {
-            animateElement(downloadButton, KEYFRAMES.pop, {
-                duration: 420,
-                easing: resolveEasing(LINEAR_EASINGS.bounce, 'cubic-bezier(0.34, 1.56, 0.64, 1)'),
-                delay: 220
+            animateElement(downloadButton, KEYFRAMES.pop, { delay: 200 }, {
+                scheme: 'standard',
+                type: 'spatial',
+                speed: 'fast'
             });
         }
     }
@@ -231,26 +472,28 @@
 
         const heading = projectsPage.querySelector('h1');
         if (heading) {
-            animateElement(heading, KEYFRAMES.slideInRight, {
-                duration: 500,
-                easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.22, 1, 0.36, 1)')
+            animateElement(heading, KEYFRAMES.slideInRight, null, {
+                scheme: 'expressive',
+                type: 'spatial',
+                speed: 'default'
             });
         }
 
         const intro = projectsPage.querySelector('.projects-intro');
         if (intro) {
-            animateElement(intro, KEYFRAMES.subtleRise, {
-                duration: 520,
-                easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.22, 1, 0.36, 1)'),
-                delay: 60
+            animateElement(intro, KEYFRAMES.subtleRise, { delay: 60 }, {
+                scheme: 'expressive',
+                type: 'spatial',
+                speed: 'default'
             });
         }
 
         const tabs = projectsPage.querySelectorAll('#projectsFilterTabs md-primary-tab');
-        animateSequence(tabs, KEYFRAMES.pop, {
-            duration: 360,
-            easing: resolveEasing(LINEAR_EASINGS.bounce, 'cubic-bezier(0.34, 1.56, 0.64, 1)')
-        }, 40);
+        animateSequence(tabs, KEYFRAMES.pop, { delay: 40 }, 36, {
+            scheme: 'expressive',
+            type: 'spatial',
+            speed: 'fast'
+        });
 
         const cards = projectsPage.querySelectorAll('.project-entry');
         animateProjectCards(cards);
@@ -261,10 +504,11 @@
             return;
         }
         const sectionChildren = container.querySelectorAll('.page-section.active > *:not(script):not(style)');
-        animateSequence(sectionChildren, KEYFRAMES.subtleRise, {
-            duration: 520,
-            easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.22, 1, 0.36, 1)')
-        }, 70);
+        animateSequence(sectionChildren, KEYFRAMES.subtleRise, { delay: 24 }, 70, {
+            scheme: 'standard',
+            type: 'spatial',
+            speed: 'default'
+        });
     }
 
     function animatePage(container, pageId) {
@@ -276,7 +520,7 @@
             return;
         }
 
-        if (!animationsEnabled()) {
+        if (!canAnimate()) {
             return;
         }
 
@@ -304,10 +548,11 @@
         if (cards.length === 0) {
             return;
         }
-        animateSequence(cards, KEYFRAMES.rise, {
-            duration: 560,
-            easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.22, 1, 0.36, 1)')
-        }, 90);
+        animateSequence(cards, KEYFRAMES.rise, { delay: 32 }, 90, {
+            scheme: 'standard',
+            type: 'spatial',
+            speed: 'default'
+        });
     }
 
     function animateSongCards(elements) {
@@ -315,10 +560,11 @@
         if (cards.length === 0) {
             return;
         }
-        animateSequence(cards, KEYFRAMES.pop, {
-            duration: 420,
-            easing: resolveEasing(LINEAR_EASINGS.bounce, 'cubic-bezier(0.34, 1.56, 0.64, 1)')
-        }, 60);
+        animateSequence(cards, KEYFRAMES.pop, { delay: 36 }, 60, {
+            scheme: 'expressive',
+            type: 'spatial',
+            speed: 'fast'
+        });
     }
 
     function animateProjectCards(elements) {
@@ -337,10 +583,11 @@
         if (cards.length === 0) {
             return;
         }
-        animateSequence(cards, KEYFRAMES.rise, {
-            duration: 640,
-            easing: resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.22, 1, 0.36, 1)')
-        }, 110);
+        animateSequence(cards, KEYFRAMES.rise, { delay: 48 }, 110, {
+            scheme: 'standard',
+            type: 'spatial',
+            speed: 'default'
+        });
     }
 
     function applyMotionEasingCustomProperties() {
@@ -355,6 +602,8 @@
             ? LINEAR_EASINGS.decelerate
             : CUBIC_EASING_FALLBACKS.decelerate;
         const standardValue = decelerateValue;
+        const springValue = resolveEasing(LINEAR_EASINGS.spring, 'cubic-bezier(0.22, 1, 0.36, 1)');
+        const bounceValue = resolveEasing(LINEAR_EASINGS.bounce, 'cubic-bezier(0.34, 1.56, 0.64, 1)');
 
         if (accelerateValue) {
             root.documentElement.style.setProperty('--app-motion-ease-accelerate', accelerateValue);
@@ -367,6 +616,14 @@
         if (standardValue) {
             root.documentElement.style.setProperty('--app-motion-ease-standard', standardValue);
         }
+
+        if (springValue) {
+            root.documentElement.style.setProperty('--app-motion-spring', springValue);
+        }
+
+        if (bounceValue) {
+            root.documentElement.style.setProperty('--app-motion-bounce', bounceValue);
+        }
     }
 
     function init() {
@@ -376,12 +633,19 @@
 
         applyMotionEasingCustomProperties();
 
-        if (!animationsEnabled()) {
-            root.documentElement.classList.add('prefers-reduced-motion');
-            return;
+        if (root.documentElement) {
+            const existingScheme = root.documentElement.dataset.motionScheme;
+            if (existingScheme && MOTION_SCHEMES[existingScheme]) {
+                activeMotionScheme = existingScheme;
+            }
         }
 
-        root.documentElement.classList.add('animations-enabled');
+        applyMotionSchemeAttributes();
+        updateMotionPreferenceClasses();
+
+        if (!canAnimate()) {
+            return;
+        }
 
         const initialContainer = root.getElementById('pageContentArea');
         if (initialContainer && initialContainer.querySelector('.profile-card')) {
@@ -396,6 +660,11 @@
         animateSongCards,
         animateProjectCards,
         resolveEasing,
+        setMotionScheme,
+        getMotionScheme,
+        schemes: MOTION_SCHEMES,
+        shouldReduceMotion,
+        canAnimate,
         easings: LINEAR_EASINGS,
         fallbacks: CUBIC_EASING_FALLBACKS
     };


### PR DESCRIPTION
## Summary
- add expressive and standard motion schemes with adaptive stagger logic so animations feel consistent with Material motion guidance
- retune home, resume, and projects page sequences to use the shared motion spec while providing graceful reduced-motion fades
- expose motion scheme helpers and share easing tokens with CSS to keep components aligned across contexts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6ec0815c832d9b2e11b9bf5df920