### PR TITLE
Use Product Sans across the site

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,5 +1,5 @@
 body {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
   background-color: var(--app-bg-color);
   color: var(--app-text-color);
   margin: 0;

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -135,7 +135,8 @@ md-chip-set {
 md-assist-chip {
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
-  --md-assist-chip-label-text-font: 'Poppins', sans-serif;
+  --md-assist-chip-label-text-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
 }
 
 /* --- Achievement Card --- */
@@ -647,7 +648,8 @@ md-list-item {
   --md-list-item-supporting-text-color: var(--app-secondary-text-color);
   --md-list-item-leading-icon-color: var(--app-text-color);
   --md-list-item-trailing-icon-color: var(--app-text-color);
-  --md-list-item-label-text-font: 'Poppins', sans-serif;
+  --md-list-item-label-text-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
 }
 
 .navigation-drawer md-list {
@@ -667,7 +669,8 @@ md-list-item {
   --md-list-item-supporting-text-color: var(--md-sys-color-on-surface-variant);
   --md-list-item-leading-icon-color: var(--md-sys-color-on-surface-variant);
   --md-list-item-trailing-icon-color: var(--md-sys-color-on-surface-variant);
-  --md-list-item-label-text-font: 'Poppins', sans-serif;
+  --md-list-item-label-text-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-list-item-leading-space: 16px;
   --md-list-item-trailing-space: 16px;
   --md-list-item-one-line-container-height: 56px;

--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -1,4 +1,23 @@
 @font-face {
+  font-family: 'JYMPDD+ProductSans-Regular';
+  src: url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.eot');
+  src:
+    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.eot?#iefix')
+      format('embedded-opentype'),
+    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.woff2')
+      format('woff2'),
+    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.woff')
+      format('woff'),
+    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.ttf')
+      format('truetype'),
+    url('https://db.onlinewebfonts.com/t/ab0f2f4d22ea179f449ca6a60f5e599c.svg#JYMPDD+ProductSans-Regular')
+      format('svg');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
   font-family: 'Material Symbols Outlined';
   font-style: normal;
   font-weight: 100 700;

--- a/assets/css/resume.css
+++ b/assets/css/resume.css
@@ -1,5 +1,5 @@
 #resumePage {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
   margin-top: 70px;
   background-color: var(--app-bg-color);
   color: var(--app-text-color);
@@ -226,7 +226,7 @@
   margin-bottom: 30px;
 }
 #resumePage .resume-section h2 {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
   font-size: 16px;
   color: #333;
   margin-bottom: 16px;
@@ -247,7 +247,7 @@
   border-bottom-color: var(--md-sys-color-primary);
 }
 #resumePage #resume-name {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
   font-size: 36px;
   font-weight: 700;
   color: #111;
@@ -255,7 +255,7 @@
   letter-spacing: -0.5px;
 }
 #resumePage #resume-job-title {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'JYMPDD+ProductSans-Regular', 'Poppins', sans-serif;
   font-size: 20px;
   color: var(--md-sys-color-secondary);
   margin-bottom: 24px;

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -74,50 +74,65 @@
   --safe-area-bottom-offset: calc(
     env(safe-area-inset-bottom, 0px) - var(--safe-area-max-inset-bottom)
   );
-  --md-sys-typescale-label-large-font-family-name: 'Poppins';
-  --md-sys-typescale-label-large-font: 'Poppins';
+  --md-sys-typescale-label-large-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-label-large-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-label-large-weight: 500;
-  --md-sys-typescale-label-medium-font-family-name: 'Poppins';
-  --md-sys-typescale-label-medium-font: 'Poppins';
+  --md-sys-typescale-label-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-label-medium-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-label-medium-weight: 500;
-  --md-sys-typescale-label-small-font-family-name: 'Poppins';
-  --md-sys-typescale-label-small-font: 'Poppins';
+  --md-sys-typescale-label-small-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-label-small-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-label-small-weight: 500;
-  --md-sys-typescale-body-large-font-family-name: 'Poppins';
-  --md-sys-typescale-body-large-font: 'Poppins';
+  --md-sys-typescale-body-large-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-body-large-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-body-large-weight: 400;
-  --md-sys-typescale-body-medium-font-family-name: 'Poppins';
-  --md-sys-typescale-body-medium-font: 'Poppins';
+  --md-sys-typescale-body-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-body-medium-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-body-medium-weight: 400;
-  --md-sys-typescale-body-small-font-family-name: 'Poppins';
-  --md-sys-typescale-body-small-font: 'Poppins';
+  --md-sys-typescale-body-small-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-body-small-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-body-small-weight: 400;
-  --md-sys-typescale-title-large-font-family-name: 'Poppins';
-  --md-sys-typescale-title-large-font: 'Poppins';
+  --md-sys-typescale-title-large-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-title-large-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-title-large-weight: 500;
-  --md-sys-typescale-title-medium-font-family-name: 'Poppins';
-  --md-sys-typescale-title-medium-font: 'Poppins';
+  --md-sys-typescale-title-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-title-medium-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-title-medium-weight: 500;
-  --md-sys-typescale-title-small-font-family-name: 'Poppins';
-  --md-sys-typescale-title-small-font: 'Poppins';
+  --md-sys-typescale-title-small-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-title-small-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-title-small-weight: 500;
-  --md-sys-typescale-headline-large-font-family-name: 'Poppins';
-  --md-sys-typescale-headline-large-font: 'Poppins';
+  --md-sys-typescale-headline-large-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-headline-large-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-headline-large-weight: 500;
-  --md-sys-typescale-headline-medium-font-family-name: 'Poppins';
-  --md-sys-typescale-headline-medium-font: 'Poppins';
+  --md-sys-typescale-headline-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-headline-medium-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-headline-medium-weight: 500;
-  --md-sys-typescale-headline-small-font-family-name: 'Poppins';
-  --md-sys-typescale-headline-small-font: 'Poppins';
+  --md-sys-typescale-headline-small-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-headline-small-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-headline-small-weight: 500;
-  --md-sys-typescale-display-large-font-family-name: 'Poppins';
-  --md-sys-typescale-display-large-font: 'Poppins';
+  --md-sys-typescale-display-large-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-display-large-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-display-large-weight: 500;
-  --md-sys-typescale-display-medium-font-family-name: 'Poppins';
-  --md-sys-typescale-display-medium-font: 'Poppins';
+  --md-sys-typescale-display-medium-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-display-medium-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-display-medium-weight: 500;
-  --md-sys-typescale-display-small-font-family-name: 'Poppins';
-  --md-sys-typescale-display-small-font: 'Poppins';
+  --md-sys-typescale-display-small-font-family-name: 'JYMPDD+ProductSans-Regular';
+  --md-sys-typescale-display-small-font: 'JYMPDD+ProductSans-Regular',
+    'Poppins', sans-serif;
   --md-sys-typescale-display-small-weight: 500;
 }
 

--- a/index.html
+++ b/index.html
@@ -91,6 +91,10 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=privacy_tip"
     />
     <link
+      href="https://db.onlinewebfonts.com/c/ab0f2f4d22ea179f449ca6a60f5e599c?family=JYMPDD%2BProductSans-Regular"
+      rel="stylesheet"
+    />
+    <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap"
       rel="stylesheet"
     />


### PR DESCRIPTION
## Summary
- load the Product Sans webfont globally and define a font-face for consistent usage
- update typography styles and Material tokens to prefer Product Sans with a Poppins fallback throughout the app

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d00d324880832d8bf8a343f2c4791f